### PR TITLE
Changing button text from view issue tracker to view repository

### DIFF
--- a/app/pages/trackers/show.html
+++ b/app/pages/trackers/show.html
@@ -22,7 +22,7 @@
 
       <a ng-href="{{tracker.url}}" target="_blank" class="btn btn-block">
         <i class="icon-globe"></i>
-        View Issue Tracker
+        View Repository
       </a>
     </div>
 


### PR DESCRIPTION
The link already goes to the repository main page rather than the issues page. I think it's better to change the text rather than the link since all the issues are present on the current page, and my experience with using the page has been "I want to go to this projects github page to see its readme and find out what it is."
