### PR TITLE
Updated grunt-contrib-connect dependency. Added hostname: '*' option so ...

### DIFF
--- a/gruntfile.js
+++ b/gruntfile.js
@@ -54,6 +54,7 @@ module.exports = function (grunt) {
       app: {
         options: {
           port: 9000,
+          hostname: '*',
           middleware: function (connect) {
             return [
               modRewrite(['!(\\.html|\\.png|\\.jpg|\\.gif|\\.jpeg|\\.ico|\\.js|\\.css|\\swf)$ /index.html']),
@@ -66,6 +67,7 @@ module.exports = function (grunt) {
       test: {
         options: {
           port: 9001,
+          hostname: '*',
           middleware: function (connect) {
             return [
               modRewrite(['!(\\.html|\\.png|\\.jpg|\\.gif|\\.jpeg|\\.ico|\\.js|\\.css|\\swf)$ /index.html']),
@@ -80,6 +82,7 @@ module.exports = function (grunt) {
         options: {
           keepalive: true,
           port: 9000,
+          hostname: '*',
           middleware: function (connect) {
             return [
               modRewrite(['!(\\.html|\\.png|\\.jpg|\\.gif|\\.jpeg|\\.ico|\\.js|\\.css|\\.swf)$ /index.html']),

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "grunt-contrib-compass": "~0.1.3",
     "grunt-contrib-jshint": "~0.3.0",
     "grunt-contrib-cssmin": "~0.5.0",
-    "grunt-contrib-connect": "~0.2.0",
+    "grunt-contrib-connect": "~0.3.0",
     "grunt-contrib-clean": "~0.4.0",
     "grunt-contrib-htmlmin": "~0.1.1",
     "grunt-contrib-imagemin": "~0.1.2",


### PR DESCRIPTION
...the server can be contacted by VMs for testing.
