### PR TITLE
Fix #78.

### DIFF
--- a/app/pages/directives.js
+++ b/app/pages/directives.js
@@ -21,6 +21,22 @@ angular.module('app').
       });
     };
   }]).
+  // Adding ng-autofill-aware to a <form> forces it to emit 'input' events on a variety of events
+  // typically triggered by autofills by the browser or password managers.
+  directive('ngAutofillAware', ['$parse', function() {
+    return function(scope, element) {
+      // listen for pertinent events to trigger input on form element
+      // use timeout to ensure val is populated before triggering 'input'
+      // ** 'change' event fires for Chrome/Firefox
+      // ** 'keydown' for Safari 6.0.1
+      // ** 'propertychange' for IE
+      element.bind('change keydown propertychange', function(event) {
+        // Trigger 'input' so underlying model changes. Don't wrap in scope.$apply as the handler
+        // will trigger its own $apply.
+        element.find('input').triggerHandler('input');
+      });
+    };
+  }]).
   directive('ngClickRequireAuth', ['$parse', '$api', function($parse, $api) {
     return {
       restrict: "A",

--- a/app/pages/signin/signin.html
+++ b/app/pages/signin/signin.html
@@ -1,4 +1,4 @@
-<form class="form-horizontal form-signin" name="form" novalidate>
+<form class="form-horizontal form-signin" name="form" novalidate ng-autofill-aware>
   <h2>Please sign in to continue</h2>
 
   <div ng-hide="provider">
@@ -31,7 +31,8 @@
   <div class="control-group" ng-class="{ error: (show_validations && form.email.$invalid) || (form.email.$error.email), success: (signin_or_signup == 'signin' || signin_or_signup == 'signup'), warning: signin_or_signup == 'pending' }">
     <label class="control-label" for="inputEmail">Email Address:</label>
     <div class="controls">
-      <input type="email" id="inputEmail" name="email" placeholder="john@doe.com" ng-model="form_data.email" ng-change="email_changing()" ng-blur="email_changed()" required />
+      <input type="email" id="inputEmail" name="email" placeholder="john@doe.com" ng-model="form_data.email" autofocus
+       ng-change="email_changing()" required />
       <span class="help-inline" ng-show="signin_or_signup=='signin'"><small>Found!</small></span>
       <span class="help-inline" ng-show="signin_or_signup=='signup'"><small>Available!</small></span>
     </div>

--- a/app/pages/signin/signin.js
+++ b/app/pages/signin/signin.js
@@ -41,6 +41,12 @@ angular.module('app')
       terms: false
     };
 
+    // If the email changes in the model (this can happen from autofill or query params),
+    // kick off the change right away.
+    $scope.$watch('form_data.email', function() {
+      $scope.email_changed();
+    });
+
     // this tracks form state
     //   null == don't show errors yet
     //   'pending' == user typed email and blurred it
@@ -57,7 +63,7 @@ angular.module('app')
     };
 
     $scope.email_changed = function() {
-      if ($scope.email_previous !== $scope.form_data.email) {
+      if ($scope.email_previous !== $scope.form_data.email && $scope.form.email.$valid) {
         $scope.email_previous = $scope.form_data.email;
         $scope.signin_or_signup = 'pending';
         $api.check_email_address($scope.form_data.email).then(function(response) {
@@ -69,11 +75,6 @@ angular.module('app')
         });
       }
     };
-
-    // if it was passsed in with query params, kick this off right away
-    if ($scope.form_data.email) {
-      $scope.email_changed();
-    }
 
     // form submit
     $scope.signin = function() {
@@ -107,5 +108,3 @@ angular.module('app')
     };
 
   });
-
-


### PR DESCRIPTION
Tested working on OSX Chrome/Firefox/Safari and Windows Chrome/Firefox/IE.

I added an `ng-autofill-aware` directive to the containing form. It will create 'input' events in response to common events fired by password managers, which will cause the model to change and `$scope.email_changed()` to be called.
