### PR TITLE
Fix max-height issue with 1022px->1253px width

### DIFF
--- a/app/styles/home.css
+++ b/app/styles/home.css
@@ -30,7 +30,7 @@
 @media (min-width: 980px) and (max-width: 1199px) {
   .homepage #top h1 { font-size: 45px; line-height: 45px; }
   .homepage #top h2 { font-size: 22px; margin: 10px 0 10px; }
-  .well { min-height: 290px; max-height: 290px;}
+  .well { min-height: 290px; max-height: 720px;}
   .search-query { width: 150px; }
   .button1 {margin-top: 20px; }
   .button2 {margin-top: 40px; }


### PR DESCRIPTION
On the /jobs site the max-height value is too low for the amount of text. Either remove it or as suggested increase it with a small buffer. The issue shows when browsing the jobs page with 1022px till 1153px as browser width.
Tested with Chromium, Chrome and Firefox.
