### PR TITLE
fixed issue #280, divs now expand to encompass all content

### DIFF
--- a/app/pages/teams/show.html
+++ b/app/pages/teams/show.html
@@ -48,7 +48,7 @@
       </div>
 
       <div class="span3">
-        <div class="well" style="min-height: 240px;">
+        <div class="well" style="min-height: 240px; max-height:500px;">
           <div style="min-height: 180px;">
             <h4>Add Projects</h4>
             <ul>
@@ -63,7 +63,7 @@
       </div>
 
       <div class="span3">
-        <div class="well" style="min-height: 240px;">
+        <div class="well" style="min-height: 240px; max-height:500px;">
           <div style="min-height: 180px;">
             <h4>Change Settings</h4>
             <ul>
@@ -84,7 +84,7 @@
         <ng-include src="'pages/teams/partials/post_bounty_box.html'"></ng-include>
       </div>
 
-      <div class="span3 well" style="min-height:280px;">
+      <div class="span3 well" style="min-height:280px; max-height:500px;">
         <div style="min-height:75%">
           <h4>Invite Members</h4>
           <ul>
@@ -97,7 +97,7 @@
           Members</a></div>
       </div>
 
-      <div class="span3 well" style="min-height:280px;" ng-show="team.type == 'Team::Startup' || team.type == 'Team::Enterprise'">
+      <div class="span3 well" style="min-height:280px; max-height:500px;" ng-show="team.type == 'Team::Startup' || team.type == 'Team::Enterprise'">
         <div style="min-height:75%">
           <h4>Add Funds</h4>
           <ul>
@@ -110,7 +110,7 @@
           Funds</a></div>
       </div>
 
-      <div class="span3 well" style="min-height:280px;" ng-show="team.type == 'Team::Project'">
+      <div class="span3 well" style="min-height:280px; max-height:500px;" ng-show="team.type == 'Team::Project'">
         <div style="min-height:75%">
           <h4>Install Plugin</h4>
           <ul>


### PR DESCRIPTION
Locally I did not exactly replicate the problem. Instead of the button covering the text, the buttons and the text would overflow from gray box. The problem was in the max-height restriction in home.css on wells so I just replaced it with a new restriction that allowed it to grow to accommodate the content. I hope this is an adequate fix

![issue 280](https://f.cloud.github.com/assets/2282402/2457492/09e185cc-af38-11e3-8bf1-b8226a83c862.png)
