### PR TITLE
added copy to clipboard option

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -11,7 +11,8 @@
     "angular-bootstrap-colorpicker": "~3.0.5",
     "es5-shim": "~2.3.0",
     "bootstrap": "=3.1.1",
-    "momentjs": "~2.5.1"
+    "momentjs": "~2.5.1",
+    "zeroclipboard": "~1.3.3"
   },
   "devDependencies": {
     "angular-mocks": "=1.2.13",

--- a/src/common/directives/clipCopy/clipCopy.js
+++ b/src/common/directives/clipCopy/clipCopy.js
@@ -1,0 +1,10 @@
+'use strict';
+angular.module('directives').directive('clipCopy', function() {
+  return {
+    restrict: 'AE',    
+    link: function(scope, elem, attrs) {
+      ZeroClipboard.config( { moviePath: "http://cdnjs.cloudflare.com/ajax/libs/zeroclipboard/1.3.2/ZeroClipboard.swf" } );
+      var client = new ZeroClipboard(elem);      
+    }
+  };
+});

--- a/src/common/directives/fundraiserTemplate/templates/fundraiserTemplate.html
+++ b/src/common/directives/fundraiserTemplate/templates/fundraiserTemplate.html
@@ -185,12 +185,30 @@
           <!--<fundraiser-tweet-button fundraiser="fundraiser"></fundraiser-tweet-button>-->
           <div class="g-plusone" data-size="medium" data-annotation="bubble" require-gplus></div>
           <br />
+          <div class="text-center">
+            <small class="text-muted">Link to this Fundraiser:</small>
+          </div>
+          <div class="input-group input-group-sm" tooltip="Copy to clipboard" tooltip-placement="left">
+            <span class="input-group-btn">
+              <button class="btn btn-default" type="button" data-clipboard-text="http://bountysource.com/fundraisers/{{fundraiser.id}}" clip-copy>
+                <span class="glyphicon glyphicon-link"></span>
+              </button>
+            </span>
+            <input type="text" class="form-control" value="http://bountysource.com/fundraisers/{{fundraiser.id}}" readonly select-on-click>      
+          </div>
           <br />
 
           <div class="text-center">
             <small class="text-muted">Embed Fundraiser on your webpage:</small>
           </div>
-          <input class="input-sm form-control" type="text" value="<iframe src='https://api.bountysource.com/user/fundraisers/{{fundraiser.id}}/embed' style='width: 238px; height: 402px; overflow: hidden; border: 0px;'></iframe>" readonly select-on-click>
+          <div class="input-group input-group-sm" tooltip="Copy to clipboard" tooltip-placement="left">
+            <span class="input-group-btn">
+              <button class="btn btn-default" type="button" data-clipboard-text="<iframe src='https://api.bountysource.com/user/fundraisers/{{fundraiser.id}}/embed' style='width: 238px; height: 402px; overflow: hidden; border: 0px;'></iframe>" clip-copy>
+                <span class="glyphicon glyphicon-link"></span>
+              </button>
+            </span>
+            <input type="text" class="form-control" value="<iframe src='https://api.bountysource.com/user/fundraisers/{{fundraiser.id}}/embed' style='width: 238px; height: 402px; overflow: hidden; border: 0px;'></iframe>" readonly select-on-click>      
+          </div>    
         </div>
       </div>
     </div>

--- a/src/index.html
+++ b/src/index.html
@@ -60,6 +60,7 @@
 <script src="vendor/angular-sanitize/angular-sanitize.js"></script>
 <script src="vendor/momentjs/moment.js"></script>
 <script src="vendor/angular-bootstrap-colorpicker/js/bootstrap-colorpicker-module.js"></script>
+<script src="vendor/zeroclipboard/ZeroClipboard.js"></script>
 <!-- endbuild -->
 <script>window.Moment = window.moment;</script>
 
@@ -153,6 +154,7 @@
     <script src="common/directives/backerThumbnails/backerThumbnails.js" type="text/javascript"></script>
     <script src="common/directives/checkoutMethodRadios/checkoutMethodRadios.js" type="text/javascript"></script>
     <script src="common/directives/claimContent/claimContent.js" type="text/javascript"></script>
+    <script src="common/directives/clipCopy/clipCopy.js" type="text/javascript"></script>
     <script src="common/directives/favicon/favicon.js" type="text/javascript"></script>
     <script src="common/directives/fundraiserEditForm/fundraiserEditForm.js" type="text/javascript"></script>
     <script src="common/directives/fundraiserSideBar/fundraiserSideBar.js" type="text/javascript"></script>


### PR DESCRIPTION
Fixes #325 
Bootstrap 3 doesn't have a 'share' glyphicon, so used the link icon. 

![clipboard](https://f.cloud.github.com/assets/3893573/2458211/3bc7de3c-af48-11e3-8887-3d530098bfa1.png)
![clipboarddone](https://f.cloud.github.com/assets/3893573/2458213/461dffba-af48-11e3-93ef-17e065ea4366.png)

Implemented using [ZeroClipboard](https://github.com/zeroclipboard/zeroclipboard). 
