### PR TITLE
scrollfix and deep-linking fragment URIs in static pages

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -9,6 +9,7 @@
     "angular-cookies": "=1.2.13",
     "angular-resource": "=1.2.13",
     "angular-bootstrap-colorpicker": "~3.0.5",
+    "angular-ui-utils": "~0.1.1",
     "es5-shim": "~2.3.0",
     "bootstrap": "=3.1.1",
     "momentjs": "~2.5.1"

--- a/src/app/about/faq.html
+++ b/src/app/about/faq.html
@@ -1,227 +1,226 @@
-<ul class="breadcrumb">
-  <li><a href="/">Home</a></li>
-  <li><a>Frequently Asked Questions</a></li>
-</ul>
-
 <div id="faq" class="container">
-<div class="row">
-<div class="col-sm-3 col-lg-3">
-  <ul class="nav nav-tabs nav-stacked" ui-scrollfix="-65">
-    <li><a href="/faq#general">General</a></li>
-    <li><a href="/faq#bounties">Bounties</a></li>
-    <li><a href="/faq#fundraisers">Fundraisers</a></li>
+  <ul class="breadcrumb">
+    <li><a href="/">Home</a></li>
+    <li><a>Frequently Asked Questions</a></li>
   </ul>
-</div>
-<div class="col-sm-9 col-lg-9">
-<h1 class="text-muted">Frequently Asked Questions</h1>
+  <div class="row">
+    <div class="col-sm-3 col-lg-3">
+      <ul class="nav nav-pills nav-stacked" ui-scrollfix="120">
+        <li><a href="/faq#general" target="_self">General</a></li>
+        <li><a href="/faq#bounties" target="_self">Bounties</a></li>
+        <li><a href="/faq#fundraisers" target="_self">Fundraisers</a></li>
+      </ul>
+    </div>
+    <div class="col-sm-9 col-lg-9">
+      <h1 class="text-muted">Frequently Asked Questions</h1>
 
-<h2 id="general">General</h2>
-<dl>
-  <dt><h4 id="what-is-bountysource">What is Bountysource?</h4></dt>
-  <dd>
-    <p>Bountysource is the funding platform for open-source software. Users can improve the open-source projects they love by creating/collecting bounties and pledging to fundraisers.</p>
-  </dd>
+      <h2 id="general">General</h2>
+      <dl>
+        <dt><h4 id="what-is-bountysource">What is Bountysource?</h4></dt>
+        <dd>
+          <p>Bountysource is the funding platform for open-source software. Users can improve the open-source projects they love by creating/collecting bounties and pledging to fundraisers.</p>
+        </dd>
 
-  <dt><h4 id="what-types-of-projects-are-allowed-on-bountysource">What types of projects are allowed on Bountysource?</h4></dt>
-  <dd>
-    <p>Any type of Open-Source or Free Software (as in speech) projects are allowed. Generally speaking, any software licenses approved by either the Open Source Initiative or the Free Software Foundation are acceptable.</p>
-    <p>See a full list of <a target="_blank" href="http://www.gnu.org/licenses/">GNU</a> or <a target="_blank" href="http://opensource.org/licenses/alphabetical">OSI-approved</a> licenses.</p>
-  </dd>
+        <dt><h4 id="what-types-of-projects-are-allowed-on-bountysource">What types of projects are allowed on Bountysource?</h4></dt>
+        <dd>
+          <p>Any type of Open-Source or Free Software (as in speech) projects are allowed. Generally speaking, any software licenses approved by either the Open Source Initiative or the Free Software Foundation are acceptable.</p>
+          <p>See a full list of <a target="_blank" href="http://www.gnu.org/licenses/">GNU</a> or <a target="_blank" href="http://opensource.org/licenses/alphabetical">OSI-approved</a> licenses.</p>
+        </dd>
 
-  <dt><h4 id="you-mentioned-free-software-how-is-that-different-from-open-source">You mentioned Free Software. How is that different from Open-Source?</h4></dt>
-  <dd>
-    <p>Free Software and Open-Source software are, generally speaking, two sides of the same coin. Both can be considered separate movements within the same community, but with varying goals. We suggest you read up on both sides yourself to better understand them.</p>
-    <ul>
-      <li><a target="_blank" href="http://www.gnu.org/philosophy/open-source-misses-the-point.html">"Free Software"</a></li>
-      <li><a target="_blank" href="http://opensource.org/faq#free-software">"Open-Source"</a></li>
-    </ul>
-  </dd>
+        <dt><h4 id="you-mentioned-free-software-how-is-that-different-from-open-source">You mentioned Free Software. How is that different from Open-Source?</h4></dt>
+        <dd>
+          <p>Free Software and Open-Source software are, generally speaking, two sides of the same coin. Both can be considered separate movements within the same community, but with varying goals. We suggest you read up on both sides yourself to better understand them.</p>
+          <ul>
+            <li><a target="_blank" href="http://www.gnu.org/philosophy/open-source-misses-the-point.html">"Free Software"</a></li>
+            <li><a target="_blank" href="http://opensource.org/faq#/free-software">"Open-Source"</a></li>
+          </ul>
+        </dd>
 
-  <dt><h4 id="how-does-bountysource-work">How does Bountysource work?</h4></dt>
-  <dd>
-    <p>There are two main functions: Fundraisers and Bounties.</p>
-    <p><i>How Bounties work:</i></p>
-    <ol>
-      <li>Users fund bounties on open issues or feature requests they want to see addressed.</li>
-      <li>These users spread the word about the bounty, enticing developers to create a solution.</li>
-      <li>Developers create solutions and claim the bounty on Bountysource.</li>
-      <li>Backers can accept or reject the claim</li>
-      <li>If accepted, Bountysource pays the bounty to the developer.</li>
-    </ol>
-    <p><i>How Fundraisers work:</i></p>
-    <ol>
-      <li>Anyone can come to Bountysource and create a Fundraiser. Open-source fundraisers are typically used to raise money for new projects, big updates to existing projects, or to raise money for bounties.</li>
-      <li>The Fundraiser creator spreads the word about the Fundraiser to the appropriate communities.</li>
-      <li>Anyone can come to Bountysource and make pledges to a Fundraiser, helping it reach its funding goal in time.</li>
-    </ol>
-  </dd>
+        <dt><h4 id="how-does-bountysource-work">How does Bountysource work?</h4></dt>
+        <dd>
+          <p>There are two main functions: Fundraisers and Bounties.</p>
+          <p><i>How Bounties work:</i></p>
+          <ol>
+            <li>Users fund bounties on open issues or feature requests they want to see addressed.</li>
+            <li>These users spread the word about the bounty, enticing developers to create a solution.</li>
+            <li>Developers create solutions and claim the bounty on Bountysource.</li>
+            <li>Backers can accept or reject the claim</li>
+            <li>If accepted, Bountysource pays the bounty to the developer.</li>
+          </ol>
+          <p><i>How Fundraisers work:</i></p>
+          <ol>
+            <li>Anyone can come to Bountysource and create a Fundraiser. Open-source fundraisers are typically used to raise money for new projects, big updates to existing projects, or to raise money for bounties.</li>
+            <li>The Fundraiser creator spreads the word about the Fundraiser to the appropriate communities.</li>
+            <li>Anyone can come to Bountysource and make pledges to a Fundraiser, helping it reach its funding goal in time.</li>
+          </ol>
+        </dd>
 
-  <dt><h4 id="why-should-i-use-bountysource">Why should I use Bountysource?</h4></dt>
-  <dd>
-    <p>There are several benefits to using Bountysource:</p>
-    <ul>
-      <li><u>Increase development.</u> Encourage developers to submit quality pull requests more frequently by creating bounties on existing issues.</li>
-      <li><u>Close issues faster.</u> Incentivize unpopular but necessary issues by adding higher bounties on them.</li>
-      <li><u>Earn money.</u> Create solutions to open issues and claim bounties within any project (including your own).</li>
-    </ul>
-  </dd>
+        <dt><h4 id="why-should-i-use-bountysource">Why should I use Bountysource?</h4></dt>
+        <dd>
+          <p>There are several benefits to using Bountysource:</p>
+          <ul>
+            <li><u>Increase development.</u> Encourage developers to submit quality pull requests more frequently by creating bounties on existing issues.</li>
+            <li><u>Close issues faster.</u> Incentivize unpopular but necessary issues by adding higher bounties on them.</li>
+            <li><u>Earn money.</u> Create solutions to open issues and claim bounties within any project (including your own).</li>
+          </ul>
+        </dd>
 
-  <dt><h4 id="i-m-an-admin-manager-committer-on-a-project-what-s-my-role-in-all-of-this">I'm an admin/manager/committer on a project. What's my role in all of this?</h4></dt>
-  <dd>
-    <p>The more developers there are working on issues within your project, the more code/solutions you will receive. You don't need to do anything out of the ordinary - just let your community know about the bounties, check for and merge code as normal, and we take care of the rest.</p>
-  </dd>
+        <dt><h4 id="i-m-an-admin-manager-committer-on-a-project-what-s-my-role-in-all-of-this">I'm an admin/manager/committer on a project. What's my role in all of this?</h4></dt>
+        <dd>
+          <p>The more developers there are working on issues within your project, the more code/solutions you will receive. You don't need to do anything out of the ordinary - just let your community know about the bounties, check for and merge code as normal, and we take care of the rest.</p>
+        </dd>
 
-  <dt><h4 id="i-m-worried-about-introducing-money-into-my-community">I'm worried about introducing money into my community.</h4></dt>
-  <dd>
-    <p>This is a reasonable hesitation. However, money has already been a part of open-source for decades. Many open-source contributors are paid by their employers to work on open-source. Many projects already have donation buttons. Many open-source developers have consulting businesses around their projects.  Ultimately, the motivations behind open-source contributions already vary widely.  The easiest way to make sense of it all is to focus on the code itself.  At the end of the day, if high-quality code is being contributed to a project, the incentives behind the code should be irrelevant.</p>
-  </dd>
-</dl>
+        <dt><h4 id="i-m-worried-about-introducing-money-into-my-community">I'm worried about introducing money into my community.</h4></dt>
+        <dd>
+          <p>This is a reasonable hesitation. However, money has already been a part of open-source for decades. Many open-source contributors are paid by their employers to work on open-source. Many projects already have donation buttons. Many open-source developers have consulting businesses around their projects.  Ultimately, the motivations behind open-source contributions already vary widely.  The easiest way to make sense of it all is to focus on the code itself.  At the end of the day, if high-quality code is being contributed to a project, the incentives behind the code should be irrelevant.</p>
+        </dd>
+      </dl>
 
-<h2 id="bounties">Bounties</h2>
-<dl>
-  <dt><h4 id="what-is-a-bounty">What is a bounty?</h4></dt>
-  <dd>
-    <p>A bounty is a cash reward put on a specific bug or feature request that encourages development.</p>
-  </dd>
+      <h2 id="bounties">Bounties</h2>
+      <dl>
+        <dt><h4 id="what-is-a-bounty">What is a bounty?</h4></dt>
+        <dd>
+          <p>A bounty is a cash reward put on a specific bug or feature request that encourages development.</p>
+        </dd>
 
-  <dt><h4 id="who-can-create-a-bounty">Who can create a bounty?</h4></dt>
-  <dd>
-    <p>Anybody with a Google Wallet or PayPal account. We plan to support other payment methods (such as Bitcoins) in the future, if there is a demand for it!</p>
-  </dd>
+        <dt><h4 id="who-can-create-a-bounty">Who can create a bounty?</h4></dt>
+        <dd>
+          <p>Anybody with a Google Wallet or PayPal account. We plan to support other payment methods (such as Bitcoins) in the future, if there is a demand for it!</p>
+        </dd>
 
-  <dt><h4 id="what-can-i-put-bounties-on">What can I put bounties on?</h4></dt>
-  <dd>
-    <p>You can create bounties on any open issue within any open-source project.</p>
-  </dd>
+        <dt><h4 id="what-can-i-put-bounties-on">What can I put bounties on?</h4></dt>
+        <dd>
+          <p>You can create bounties on any open issue within any open-source project.</p>
+        </dd>
 
-  <dt><h4 id="what-does-it-cost-to-post-a-bounty">What does it cost to post a bounty?</h4></dt>
-  <dd>
-    <p>Bountysource charges a 10% non-refundable fee for placing bounties in addition to the specific bounty amount. For example, to place a $50 bounty, you will be charged a total of $55.</p>
-    <p>You will be required to pay the full amount of the bounty in order for the bounty to show up on Bountysource.</p>
-  </dd>
+        <dt><h4 id="what-does-it-cost-to-post-a-bounty">What does it cost to post a bounty?</h4></dt>
+        <dd>
+          <p>Bountysource charges a 10% non-refundable fee for placing bounties in addition to the specific bounty amount. For example, to place a $50 bounty, you will be charged a total of $55.</p>
+          <p>You will be required to pay the full amount of the bounty in order for the bounty to show up on Bountysource.</p>
+        </dd>
 
-  <dt><h4 id="do-i-have-to-be-affiliated-with-a-project-in-order-to-put-a-bounty-on-an-issue">Do I have to be affiliated with a project in order to put a bounty on an issue?</h4></dt>
-  <dd>
-    <p>No. Anybody can put a bounty on any issue, regardless of their relationship with the project.</p>
-  </dd>
+        <dt><h4 id="do-i-have-to-be-affiliated-with-a-project-in-order-to-put-a-bounty-on-an-issue">Do I have to be affiliated with a project in order to put a bounty on an issue?</h4></dt>
+        <dd>
+          <p>No. Anybody can put a bounty on any issue, regardless of their relationship with the project.</p>
+        </dd>
 
-  <!--
-  <dt><h4 id="how-do-i-add-a-my-project-to-bountysource">How do I add a/my project to Bountysource?</h4></dt>
-  <dd>
-    <p>Bountysource does not host projects. Instead, we read data from other issue trackers. You don't "add" a project to Bountysource, but you "tell" Bountysource about a project. You can tell Bountysource about a project via Search.</p>
-  </dd>
-  -->
+        <!--
+        <dt><h4 id="how-do-i-add-a-my-project-to-bountysource">How do I add a/my project to Bountysource?</h4></dt>
+        <dd>
+          <p>Bountysource does not host projects. Instead, we read data from other issue trackers. You don't "add" a project to Bountysource, but you "tell" Bountysource about a project. You can tell Bountysource about a project via Search.</p>
+        </dd>
+        -->
 
-  <dt><h4 id="does-100-of-the-bounty-go-to-the-developer">Does 100% of the bounty go to the developer?</h4></dt>
-  <dd>
-    <p>Yes. The developer who solves the issue will receive the full bounty displayed.</p>
-  </dd>
+        <dt><h4 id="does-100-of-the-bounty-go-to-the-developer">Does 100% of the bounty go to the developer?</h4></dt>
+        <dd>
+          <p>Yes. The developer who solves the issue will receive the full bounty displayed.</p>
+        </dd>
 
-  <dt><h4 id="what-does-it-cost-to-claim-a-bounty">What does it cost to claim a bounty?</h4></dt>
-  <dd>
-    <p>Nothing. The amount displayed as the bounty total is the exact amount a developer will receive in their Bountysource account upon payout.</p>
-  </dd>
+        <dt><h4 id="what-does-it-cost-to-claim-a-bounty">What does it cost to claim a bounty?</h4></dt>
+        <dd>
+          <p>Nothing. The amount displayed as the bounty total is the exact amount a developer will receive in their Bountysource account upon payout.</p>
+        </dd>
 
-  <dt><h4 id="can-several-people-put-bounties-on-the-same-issue">Can several people put bounties on the same issue?</h4></dt>
-  <dd>
-    <p>Yes! That is ideal. A $50 bounty from one person might not be appealing, but a $2,000 bounty from 25 people would be!</p>
-  </dd>
+        <dt><h4 id="can-several-people-put-bounties-on-the-same-issue">Can several people put bounties on the same issue?</h4></dt>
+        <dd>
+          <p>Yes! That is ideal. A $50 bounty from one person might not be appealing, but a $2,000 bounty from 25 people would be!</p>
+        </dd>
 
-  <dt><h4 id="what-happens-after-i-post-a-bounty">What happens after I post a bounty?</h4></dt>
-  <dd>
-    <p>We monitor the issue until it's in a fixed/resolved state. After the issue is resolved, the developer who solved the issue can come to Bountysource to claim the bounty. If you're a Backer, we'll keep you informed (via email) of any Claim activity on the issue.</p>
-  </dd>
+        <dt><h4 id="what-happens-after-i-post-a-bounty">What happens after I post a bounty?</h4></dt>
+        <dd>
+          <p>We monitor the issue until it's in a fixed/resolved state. After the issue is resolved, the developer who solved the issue can come to Bountysource to claim the bounty. If you're a Backer, we'll keep you informed (via email) of any Claim activity on the issue.</p>
+        </dd>
 
-  <dt><h4 id="how-are-claims-processed">How are claims processed?</h4></dt>
-  <dd>
-    <p>When a bounty claim is submitted by a developer, the claim is put into a two week verification period. Backers are notified by email and can then accept or reject the claim.</p>
-    <ul>
-      <li>If all Backers vote to accept the claim, it is processed immediately and the developer is awarded the bounty.</li>
-      <li>If any Backer fails to accept the claim, it remains in the two week waiting period.</li>
-      <li>If any Backer has an issue with the claim, they can reject it. Claims cannot be paid out until the dispute is resolved and the rejected status is lifted.</li>
-    </ul>
-  </dd>
+        <dt><h4 id="how-are-claims-processed">How are claims processed?</h4></dt>
+        <dd>
+          <p>When a bounty claim is submitted by a developer, the claim is put into a two week verification period. Backers are notified by email and can then accept or reject the claim.</p>
+          <ul>
+            <li>If all Backers vote to accept the claim, it is processed immediately and the developer is awarded the bounty.</li>
+            <li>If any Backer fails to accept the claim, it remains in the two week waiting period.</li>
+            <li>If any Backer has an issue with the claim, they can reject it. Claims cannot be paid out until the dispute is resolved and the rejected status is lifted.</li>
+          </ul>
+        </dd>
 
-  <dt><h4 id="what-if-i-m-unsatisfied-with-the-solution-to-an-issue-i-ve-backed">What if I'm unsatisfied with the solution to an issue I've backed?</h4></dt>
-  <dd>
-    <p>After a claim is submitted, you will have two weeks to open any disputes you may have.</p>
-  </dd>
+        <dt><h4 id="what-if-i-m-unsatisfied-with-the-solution-to-an-issue-i-ve-backed">What if I'm unsatisfied with the solution to an issue I've backed?</h4></dt>
+        <dd>
+          <p>After a claim is submitted, you will have two weeks to open any disputes you may have.</p>
+        </dd>
 
-  <dt><h4 id="how-can-i-keep-track-of-all-the-bounties-i-ve-posted">How can I keep track of all the bounties I've posted?</h4></dt>
-  <dd>
-    <p>You can view all of the issues you've backed via your <a target="_blank" href="/activity/bounties">Activity page</a>.</p>
-  </dd>
+        <dt><h4 id="how-can-i-keep-track-of-all-the-bounties-i-ve-posted">How can I keep track of all the bounties I've posted?</h4></dt>
+        <dd>
+          <p>You can view all of the issues you've backed via your <a target="_blank" href="/activity/bounties">Activity page</a>.</p>
+        </dd>
 
-  <dt><h4 id="an-issue-i-ve-backed-has-been-closed-when-will-the-solution-be-made-available-to-the-public">An issue I've backed has been closed. When will the solution be made available to the public?</h4></dt>
-  <dd>
-    <p>We have no control over when a project makes a new release. We award a bounty once code has been merged into the project. The rest is up to project owners and committers.</p>
-  </dd>
+        <dt><h4 id="an-issue-i-ve-backed-has-been-closed-when-will-the-solution-be-made-available-to-the-public">An issue I've backed has been closed. When will the solution be made available to the public?</h4></dt>
+        <dd>
+          <p>We have no control over when a project makes a new release. We award a bounty once code has been merged into the project. The rest is up to project owners and committers.</p>
+        </dd>
 
-  <dt><h4 id="what-happens-if-an-issue-i-ve-backed-is-closed-without-resolution">What happens if an issue I've backed is closed without resolution?</h4></dt>
-  <dd>
-    <p>If the issue was closed because it was a duplicate of another issue, we will transfer the bounty to the appropriate issue.</p>
-    <p>If the issue was closed as a "won't fix", or is deemed not in line with the project's goals, the bounty amount is refunded.</p>
-  </dd>
+        <dt><h4 id="what-happens-if-an-issue-i-ve-backed-is-closed-without-resolution">What happens if an issue I've backed is closed without resolution?</h4></dt>
+        <dd>
+          <p>If the issue was closed because it was a duplicate of another issue, we will transfer the bounty to the appropriate issue.</p>
+          <p>If the issue was closed as a "won't fix", or is deemed not in line with the project's goals, the bounty amount is refunded.</p>
+        </dd>
 
-  <dt><h4 id="how-do-you-know-a-project-committer-will-accept-any-pull-requests-at-all">How do you know a project committer will accept any pull requests at all?</h4></dt>
-  <dd>
-    <p>We don't guarantee this, but one of the main points of open-source software and making code public is to foster improvement. Committers are always monitoring pull requests, and they likely will accept any and all code they feel is of quality.</p>
-  </dd>
+        <dt><h4 id="how-do-you-know-a-project-committer-will-accept-any-pull-requests-at-all">How do you know a project committer will accept any pull requests at all?</h4></dt>
+        <dd>
+          <p>We don't guarantee this, but one of the main points of open-source software and making code public is to foster improvement. Committers are always monitoring pull requests, and they likely will accept any and all code they feel is of quality.</p>
+        </dd>
 
-  <dt><h4 id="how-do-i-receive-payment">How do I receive payment?</h4></dt>
-  <dd>
-    <p>Once your claim has been accepted the money is automatically placed into your Bountysource account. To request a cashout of your current Bountysource balance, please <a target="_blank" href="/activity/transactions">click here</a>.</p>
-  </dd>
+        <dt><h4 id="how-do-i-receive-payment">How do I receive payment?</h4></dt>
+        <dd>
+          <p>Once your claim has been accepted the money is automatically placed into your Bountysource account. To request a cashout of your current Bountysource balance, please <a target="_blank" href="/activity/transactions">click here</a>.</p>
+        </dd>
 
-  <dt><h4 id="do-i-have-to-pay-taxes-on-bounties-i-collect">Do I have to pay taxes on bounties I collect?</h4></dt>
-  <dd>
-    <p>If you are in the United States and payments made to you are more than $600 for the year, we are required to issue you a Form 1099 to report the payments, which will require you to complete a Form W-9. You should consult your tax advisor as to the taxability of the payments.</p>
-  </dd>
-</dl>
+        <dt><h4 id="do-i-have-to-pay-taxes-on-bounties-i-collect">Do I have to pay taxes on bounties I collect?</h4></dt>
+        <dd>
+          <p>If you are in the United States and payments made to you are more than $600 for the year, we are required to issue you a Form 1099 to report the payments, which will require you to complete a Form W-9. You should consult your tax advisor as to the taxability of the payments.</p>
+        </dd>
+      </dl>
 
-<h2 id="fundraisers">Fundraisers</h2>
-<dl>
-  <dt><h4 id="what-is-a-fundraiser">What is a Fundraiser?</h4></dt>
-  <dd>
-    <p>A Fundraiser is a time-limited campaign that allows open-source developers to raise money from their community.</p>
-    <p>Bountysource fundraisers employ the "flexible funding" model. This means that a fundraiser creator receives all money pledged, regardless of whether or not the funding goal is met.</p>
-  </dd>
+      <h2 id="fundraisers">Fundraisers</h2>
+      <dl>
+        <dt><h4 id="what-is-a-fundraiser">What is a Fundraiser?</h4></dt>
+        <dd>
+          <p>A Fundraiser is a time-limited campaign that allows open-source developers to raise money from their community.</p>
+          <p>Bountysource fundraisers employ the "flexible funding" model. This means that a fundraiser creator receives all money pledged, regardless of whether or not the funding goal is met.</p>
+        </dd>
 
-  <dt><h4 id="who-can-create-a-fundraiser">Who can create a fundraiser?</h4></dt>
-  <dd>
-    <p>Anybody!</p>
-  </dd>
+        <dt><h4 id="who-can-create-a-fundraiser">Who can create a fundraiser?</h4></dt>
+        <dd>
+          <p>Anybody!</p>
+        </dd>
 
-  <dt><h4 id="what-does-it-cost-to-start-a-fundraiser">What does it cost to start a fundraiser?</h4></dt>
-  <dd>
-    <p>Nothing! Go <a target="_blank" href="/#account/create_fundraiser">start one</a> today.</p>
-  </dd>
+        <dt><h4 id="what-does-it-cost-to-start-a-fundraiser">What does it cost to start a fundraiser?</h4></dt>
+        <dd>
+          <p>Nothing! Go <a target="_blank" href="/#account/create_fundraiser">start one</a> today.</p>
+        </dd>
 
-  <dt><h4 id="what-happens-if-the-fundraising-goal-isn-t-met">What happens if the fundraising goal isn't met?</h4></dt>
-  <dd>
-    <p>The fundraiser creator receives all money pledged (less the Bountysource fee) even if the funding goal is not met.</p>
-  </dd>
+        <dt><h4 id="what-happens-if-the-fundraising-goal-isn-t-met">What happens if the fundraising goal isn't met?</h4></dt>
+        <dd>
+          <p>The fundraiser creator receives all money pledged (less the Bountysource fee) even if the funding goal is not met.</p>
+        </dd>
 
-  <dt><h4 id="what-fees-are-there">What fees are there?</h4></dt>
-  <dd>A 10% fee is deducted from each pledge. This fee includes the payment processing fees incurred for collecting pledges. There are no other fees or charges from Bountysource. For more information, please see our <a href="/fees">Pricing page</a>.
-  </dd>
+        <dt><h4 id="what-fees-are-there">What fees are there?</h4></dt>
+        <dd>A 10% fee is deducted from each pledge. This fee includes the payment processing fees incurred for collecting pledges. There are no other fees or charges from Bountysource. For more information, please see our <a href="/fees">Pricing page</a>.
+        </dd>
 
-  <dt><h4 id="when-do-i-get-paid">When do I get paid?</h4></dt>
-  <dd>
-    <p>We potentially make two payouts - the first payout happens when the fundraiser meets its goal, and the second payout could happen when the fundraiser expires (for any additional pledges). For more information, please see our <a href="/fees">Pricing page</a>.</p>
-  </dd>
+        <dt><h4 id="when-do-i-get-paid">When do I get paid?</h4></dt>
+        <dd>
+          <p>We potentially make two payouts - the first payout happens when the fundraiser meets its goal, and the second payout could happen when the fundraiser expires (for any additional pledges). For more information, please see our <a href="/fees">Pricing page</a>.</p>
+        </dd>
 
-  <dt><h4 id="what-makes-fundraisers-different-from-kickstarter-indiegogo-etc">What makes Fundraisers different from Kickstarter, Indiegogo, etc?</h4></dt>
-  <dd>
-    <ul>
-      <li>We help legitimize open-source projects by connecting them with top tech companies like Adobe, Walmart Labs and Mozilla. We have an entire team dedicated to connecting developers with potential sponsors.</li>
-      <li>Our platform is tailor-made for developers, and is designed to minimize overhead administration in order to allow the developer to focus entirely fulfilling milestones promised in their fundraiser. With that in mind, we offer full-service merchandise fulfillment for standard fundraising perks such as T-shirts and stickers. Please <a href="mailto:support@bountysource.com">contact us</a> for more details.</li>
-      <li>We're not just an arbiter of funds. Our team works side-by-side with developers to support their projects that are using the system. Users have a direct line of communication with us via <a href="irc://irc.freenode.net/bountysource">IRC (#bountysource on Freenode)</a>.</li>
-    </ul>
-  </dd>
-</dl>
+        <dt><h4 id="what-makes-fundraisers-different-from-kickstarter-indiegogo-etc">What makes Fundraisers different from Kickstarter, Indiegogo, etc?</h4></dt>
+        <dd>
+          <ul>
+            <li>We help legitimize open-source projects by connecting them with top tech companies like Adobe, Walmart Labs and Mozilla. We have an entire team dedicated to connecting developers with potential sponsors.</li>
+            <li>Our platform is tailor-made for developers, and is designed to minimize overhead administration in order to allow the developer to focus entirely fulfilling milestones promised in their fundraiser. With that in mind, we offer full-service merchandise fulfillment for standard fundraising perks such as T-shirts and stickers. Please <a href="mailto:support@bountysource.com">contact us</a> for more details.</li>
+            <li>We're not just an arbiter of funds. Our team works side-by-side with developers to support their projects that are using the system. Users have a direct line of communication with us via <a href="irc://irc.freenode.net/bountysource">IRC (#bountysource on Freenode)</a>.</li>
+          </ul>
+        </dd>
+      </dl>
 
-<p>Have any further questions? <a href="mailto:support@bountysource.com">Contact us!</a></p>
-</div>
-</div>
+      <p>Have any further questions? <a href="mailto:support@bountysource.com">Contact us!</a></p>
+    </div>
+  </div>
 </div>

--- a/src/app/about/fees.html
+++ b/src/app/about/fees.html
@@ -1,19 +1,18 @@
-<ul class="breadcrumb">
-  <li><a href="/">Home</a></li>
-  <li><a>Fees & Payments</a></li>
-</ul>
-
 <div id="fees" class="container">
+  <ul class="breadcrumb">
+    <li><a href="/">Home</a></li>
+    <li><a>Fees &amp; Payments</a></li>
+  </ul>
   <div class="row">
     <div class="col-sm-3 col-md-3">
-      <ul class="nav nav-tabs nav-stacked" ui-scrollfix="-65">
-        <li><a href="/fees#fundraiser-fees">Fundraiser Fees</a></li>
-        <li><a href="/fees#bounty-fees">Bounty Fees</a></li>
-        <li><a href="/fees#payments">Payments</a></li>
+      <ul class="nav nav-pills nav-stacked" ui-scrollfix="120">
+        <li><a href="/fees#fundraiser-fees" target="_self">Fundraiser Fees</a></li>
+        <li><a href="/fees#bounty-fees" target="_self">Bounty Fees</a></li>
+        <li><a href="/fees#payments" target="_self">Payments</a></li>
       </ul>
     </div>
     <div class="col-sm-9 col-md-9">
-      <h1 class="text-muted">Fees & Payments</h1>
+      <h1 class="text-muted">Fees &amp; Payments</h1>
 
       <h2 id="fundraiser-fees">Fundraiser Fees</h2>
       <dl>

--- a/src/app/about/jobs.html
+++ b/src/app/about/jobs.html
@@ -1,19 +1,18 @@
-<ul class="breadcrumb">
-  <li><a href="/">Home</a></li>
-  <li><a>Jobs</a></li>
-</ul>
-
 <div id="jobs" class="container">
+  <ul class="breadcrumb">
+    <li><a href="/">Home</a></li>
+    <li><a>Jobs</a></li>
+  </ul>
   <div class="row">
     <div class="col-sm-6 col-md-6">
       <div class="jumbotron">
         <h2 style="margin-bottom: 1em;">Bountysource</h2>
-        <p>Bountysource is a fast-growing startup that is constantly on the hunt for top talent. We are located in the Financial District of San Francisco (3rd & Market) with easy access to BART and MUNI.</p>
+        <p>Bountysource is a fast-growing startup that is constantly on the hunt for top talent. We are located in the Financial District of San Francisco (3rd &amp; Market) with easy access to BART and MUNI.</p>
         <p>To apply to any of these positions, please drop us a line at jobs@bountysource.com. Resumes and cover letters are important, but so are GitHub profiles and open-source contributions.</p>
       </div>
     </div>
     <div class="col-sm-6 col-md-6">
-      <h1 class="text-muted" style="margin: 0; margin-bottom: 30px;">Jobs</h1>
+      <h1 class="text-muted" style="margin-bottom: 30px;">Jobs</h1>
       <div class="well">
         <h3>Senior Ruby on Rails Engineer</h3>
         <div>
@@ -34,7 +33,7 @@
           <ul>
             <li>Data mining / analysis of open source projects</li>
             <li>Generating reports on user activity</li>
-            <li>Quality Assurance testing & feedback</li>
+            <li>Quality Assurance testing &amp; feedback</li>
             <li>Assisting in outreach efforts</li>
           </ul>
           <p><strong>We are looking for an individual who possesses the following:</strong></p>

--- a/src/app/about/static.js
+++ b/src/app/about/static.js
@@ -1,6 +1,13 @@
 'use strict';
 
-angular.module('app').controller('StaticPageController', function () {
-  // does absolutely nothing... inherit this for static pages!!
+angular.module('app').controller('StaticPageController', function ($scope, $location, $anchorScroll, $routeParams) {
+  // Inherit this for static pages that need deep-linking of hash fragments!
+
+  var hash = $location.hash();
+
+  if (hash.length > 0) {
+    $location.hash(hash.replace(/^\/+/, '')); $anchorScroll();
+  }
+
   return true;
 });

--- a/src/app/app.js
+++ b/src/app/app.js
@@ -43,7 +43,8 @@ angular.module('app', [
   'ui.bootstrap',
   'colorpicker.module',
   'fundraisers',
-  'teams'
+  'teams',
+  'ui.scrollfix'
 ]);
 
 angular.module('app')

--- a/src/index.html
+++ b/src/index.html
@@ -61,6 +61,7 @@
 <script src="vendor/angular-sanitize/angular-sanitize.js"></script>
 <script src="vendor/momentjs/moment.js"></script>
 <script src="vendor/angular-bootstrap-colorpicker/js/bootstrap-colorpicker-module.js"></script>
+<script src="vendor/angular-ui-utils/ui-utils.js"></script>
 <!-- endbuild -->
 <script>window.Moment = window.moment;</script>
 

--- a/src/less/about.css
+++ b/src/less/about.css
@@ -14,16 +14,22 @@
 }
 
 .ui-scrollfix {
-  position: fixed;
-  top: 65px;
-  width: 270px;
+  position: static;
+  width: auto;
+  margin-bottom: 20px;
+  display: block;
 }
 
-@media (max-width: 767px) {
+@media (min-width: 768px) {
+  #faq h1,
+  #fees h1,
+  #jobs h1 {
+    margin-top: 0;
+  }
+
   .ui-scrollfix {
-    position: static;
-    width: auto;
-    margin-bottom: 20px;
-    display: block;
+    position: fixed;
+    top: 10px;
+    width: 270px;
   }
 }


### PR DESCRIPTION
Closes #95 for Bootstrap 3.
- [x] Pricing page
- [x] FAQ
- [x] Jobs
- [x] Can link to individual questions/sections

Other fixes:
- moved `.breadcrumb` inside the `.container` to keep the horizontal alignment
- switched from `nav-tabs nav-stacked` to `nav-pills nav-stacked` ([`nav-tabs` shouldn't be stacked](http://getbootstrap.com/components/#nav-pills))
- side menu stays visible in the viewport (when width >= 768px) as requested [here](https://github.com/bountysource/frontend/issues/95#issuecomment-24775678)

Linking to individual sections is supported:
- https://www.bountysource.com/faq#bounties
- https://www.bountysource.com/faq#what-does-it-cost-to-post-a-bounty
- https://www.bountysource.com/fees#bounty-fees
- https://www.bountysource.com/fees#placing-a-bounty
