### PR TITLE
In the V2 tracker response, tracker.url broken

### DIFF
--- a/src/app/issues/templates/solution_form.html
+++ b/src/app/issues/templates/solution_form.html
@@ -7,7 +7,7 @@
           <ol>
             <li>To keep backers and other developers in the loop, please fill out as much information as possible.</li>
             <li>Now that you're ready to solve the issue, you should update everyone on the <a ng-href="{{issue.url}}">original issue tracker</a>.</li>
-            <li>Get the <a ng-href="{{ issue.tracker.url }}">code!</a></li>
+            <li>Get the <a ng-href="{{ issue.tracker.repo_url }}" target="_blank">code!</a></li>
             <li>Good luck! Now get coding!</li>
           </ol>
         </div>


### PR DESCRIPTION
Hey @slicebo123, please review this change.

This will resolve this issue: https://github.com/bountysource/frontend/issues/594
![screen shot 2014-05-05 at 3 31 05 pm](https://cloud.githubusercontent.com/assets/506085/2884114/2b71ae78-d4a5-11e3-84b6-4a8ed5d8a9cb.png)

Using the V2 API for trackers, we moved from using tracker.url to tracker.repo_url, which is controlled by the user
