### PR TITLE
Add error handling for no repo_url

### DIFF
--- a/src/app/issues/templates/solution_form.html
+++ b/src/app/issues/templates/solution_form.html
@@ -7,7 +7,8 @@
           <ol>
             <li>To keep backers and other developers in the loop, please fill out as much information as possible.</li>
             <li>Now that you're ready to solve the issue, you should update everyone on the <a ng-href="{{issue.url}}">original issue tracker</a>.</li>
-            <li>Get the <a ng-href="{{ issue.tracker.repo_url }}" target="_blank">code!</a></li>
+            <li ng-show="issue.tracker.repo_url">Get the <a ng-href="{{ issue.tracker.repo_url }}" target="_blank">code!</a></li>
+            <li ng-show="!issue.tracker.repo_url">Get the code!</li>
             <li>Good luck! Now get coding!</li>
           </ol>
         </div>


### PR DESCRIPTION
@slicebo123 please review, @rappo FYI

This should handle when there is no repo_url, and display a plain text step instead.

![screen shot 2014-05-06 at 4 17 12 pm](https://cloud.githubusercontent.com/assets/506085/2896885/9a6822d8-d574-11e3-958b-de4726b4f85f.png)

Relates to: https://github.com/bountysource/frontend/issues/594
