### PR TITLE
Fix team payin custom amount input

### DIFF
--- a/src/common/directives/teamView/teamView.js
+++ b/src/common/directives/teamView/teamView.js
@@ -186,7 +186,7 @@ angular.module('directives').directive('teamView', function($rootScope, $locatio
 
       scope.customPayinRedirect = function (amount) {
         $analytics.teamPayinStart({ amount: amount, type: 'custom'});
-        scope.pledgeRedirect(amount);
+        scope.payinRedirect(amount);
       };
 
       scope.customPledgeRedirect = function(amount) {


### PR DESCRIPTION
It was using the pledge method which waits for `activeFundraiser`, but that doesn't exist for teams without an active fundraiser.
