### PR TITLE
Fixes team dropdown for add_funds

### DIFF
--- a/src/common/directives/teamView/templates/teamView.html
+++ b/src/common/directives/teamView/templates/teamView.html
@@ -191,7 +191,7 @@
               <li class="dropdown-header"><i class="glyphicon glyphicon-cog"></i> General</li>
 
               <li ng-show="is_admin">
-                <a ng-href="/teams/{{team.slug}}/account">Add Funds</a>
+                <a ng-click="adminPayinRedirect()">Add Funds</a>
               </li>
 
               <li ng-show="is_admin">


### PR DESCRIPTION
Updates `Add Funds` dropdown to add item to cart and redirect to cart page. /team/:id/account page is no more.
@juliangiuca, could you review this?
