### PR TITLE
Have the Ripple symbol show up as XRP instead

### DIFF
--- a/src/app/layout/navbar.html
+++ b/src/app/layout/navbar.html
@@ -40,7 +40,7 @@
           <a href="#" class="dropdown-toggle" data-toggle="dropdown">
             <span ng-if="$currency.isUSD()">Pricing: $</span>
             <span ng-if="$currency.isBTC()">Pricing: ฿</span>
-            <span ng-if="$currency.isXRP()">Pricing: Ʀ</span>
+            <span ng-if="$currency.isXRP()">Pricing: XRP</span>
             <span ng-if="$currency.isMSC()">Pricing: MSC</span>
             <b class="caret"></b>
           </a>
@@ -50,7 +50,7 @@
             <li role="presentation" class="dropdown-header">Choose currency:</li>
             <li><a ng-click="$currency.setUSD()">US Dollars ($)</a></li>
             <li><a ng-click="$currency.setBTC()">Bitcoin (฿)</a></li>
-            <li><a ng-click="$currency.setXRP()">Ripple (Ʀ)</a></li>
+            <li><a ng-click="$currency.setXRP()">Ripple (XRP)</a></li>
             <li><a ng-click="$currency.setMSC()">Mastercoin (MSC)</a></li>
           </ul>
         </li>

--- a/src/common/directives/currencyUnit/templates/currencyUnit.html
+++ b/src/common/directives/currencyUnit/templates/currencyUnit.html
@@ -1,6 +1,6 @@
 <span ng-switch on="$currency.value">
   <span ng-switch-when="USD">$</span>
   <span ng-switch-when="BTC">฿</span>
-  <span ng-switch-when="XRP">Ʀ</span>
+  <span ng-switch-when="XRP">XRP</span>
   <span ng-switch-when="MSC">MSC</span>
 </span>

--- a/src/common/filters/currencyUnit.js
+++ b/src/common/filters/currencyUnit.js
@@ -11,7 +11,7 @@ angular.module('filters').filter('currencyUnit', function ($filter) {
         return 'μBTC ';
       }
     } else if (currency === 'XRP') {
-      return 'Ʀ';
+      return 'XRP';
     } else if (currency === 'MSC') {
       return 'MSC';
     } else if (currency === 'USD') {

--- a/src/common/services/currency.js
+++ b/src/common/services/currency.js
@@ -227,7 +227,7 @@ angular.module('services').service('$currency', function ($rootScope, $cookieSto
   * */
   this.hasSymbol = function (currencyIso) {
     currencyIso = currencyIso || this.value;
-    return this.isUSD(currencyIso) || this.isBTC(currencyIso) || this.isXRP(currencyIso);
+    return this.isUSD(currencyIso) || this.isBTC(currencyIso);
   };
 
 });


### PR DESCRIPTION
@slicebo123 please review. 
- Swapping from the "R" Ripple symbol to the "XRP" symbol. 
- Move the XRP to the end of the money string

We also don't want the XRP showing up on the bounty buttons, but it looks like I got that for free.

Solves to #669 
