### PR TITLE
Update node.js to 0.10 in travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: node_js
 
 node_js:
-  - 0.8
+  - "0.10"
 
 before_script:
   - npm install --quiet -g grunt-cli


### PR DESCRIPTION
Sets the node version to 0.10, which is the minimum required by bower in Travis.
