### PR TITLE
Admin RFP toggle

### DIFF
--- a/src/app/teams/base.js
+++ b/src/app/teams/base.js
@@ -1,13 +1,13 @@
 'use strict';
 
-angular.module('app').controller('BaseTeamController', function($scope, $location, $routeParams, $api, $pageTitle, $rootScope) {
+angular.module('app').controller('BaseTeamController', function($scope, $location, $routeParams, $api, $pageTitle, Team) {
   $pageTitle.set("Teams");
 
   $scope.team_promise = $api.v2.team($routeParams.id).then(function(response) {
     if (!response.success) {
       $scope.no_team_error = response.data.error;
     } else {
-      $scope.team = angular.copy(response.data);
+      $scope.team = new Team(angular.copy(response.data));
 
       // Parse ints back into strings
       $scope.team.open_bounties_amount = parseInt($scope.team.open_bounties_amount, 10);

--- a/src/common/directives/teamView/templates/teamView.html
+++ b/src/common/directives/teamView/templates/teamView.html
@@ -12,6 +12,19 @@
     <!-- LEFT COLUMN -->
     <div class="col-lg-3 col-md-3 col-sm-3">
 
+      <!-- Admin Only -->
+      <div ng-if="current_person.admin">
+        <div class="panel panel-default">
+          <div class="panel-heading text-center">Admin</div>
+          <div class="panel-body">
+            <button class="btn btn-default btn-small btn-block" ng-click="team.toggleRfpEnabled()">
+              <span ng-if="!team.rfp_enabled">Enable RFP</span>
+              <span ng-if="team.rfp_enabled">Disable RFP</span>
+            </button>
+          </div>
+        </div>
+      </div>
+
       <!-- Team Info. Includes active Fundraiser progress if there is one running -->
       <div class="panel panel-default">
         <div class="panel-body">

--- a/src/common/factories/Team.js
+++ b/src/common/factories/Team.js
@@ -1,0 +1,32 @@
+'use strict';
+
+angular.module('factories').factory('Team', function ($rootScope, $resource, $api) {
+
+  var defaultHeaders = { 'Accept': 'application/vnd.bountysource+json; version=2' };
+
+  var Team = $resource($rootScope.api_host + 'teams/:slug/:action', { slug: '@slug' }, {
+    get: { method: 'GET', headers: defaultHeaders },
+    query: { method: 'GET', headers: defaultHeaders, isArray: true },
+    update: { method: 'PATCH', headers: defaultHeaders }
+  });
+
+  /**
+   * Does this team have the RFP feature enabled?
+   * */
+  Team.prototype.rfpEnabled = function () {
+    return !!this.rfp_enabled;
+  };
+
+  /**
+   * Toggle the RFP feature for this team. Requires user to be a Bountysource admin
+   * */
+  Team.prototype.toggleRfpEnabled = function () {
+    return this.$update({
+      access_token: $api.get_access_token(),
+      rfp_enabled: !this.rfpEnabled()
+    });
+  };
+
+  return Team;
+
+});

--- a/src/index.html
+++ b/src/index.html
@@ -215,6 +215,7 @@
     <script src="common/factories/IssueBadge.js" type="text/javascript"></script>
     <script src="common/factories/NavTab.js" type="text/javascript"></script>
     <script src="common/factories/Pagination.js" type="text/javascript"></script>
+    <script src="common/factories/Team.js" type="text/javascript"></script>
     <script src="common/factories/TeamBadge.js" type="text/javascript"></script>
     <script src="common/factories/TeamBadgeBountiesPosted.js" type="text/javascript"></script>
     <script src="common/factories/TeamBadgeBountiesReceived.js" type="text/javascript"></script>


### PR DESCRIPTION
Issue: #724

> As a member of Bountysource
> When a team has requested RFP's be enabled for them
> Then we go to the team page
> And I press "Enable RFP's for this team"
- Render a panel if current user is a Bountysource admin (`people.admin`) with "Enable RFP" button.

![image](https://cloud.githubusercontent.com/assets/692632/3098973/773c8ca0-e5f4-11e3-8302-d0d50876ad71.png)
- Teams update action accepts `rfp_enabled` as a boolean param, requires current user to be admin to complete update if that attribute is modified.
