### PR TITLE
Require auth on proposals tab

### DIFF
--- a/src/app/issues/templates/nav_tabs.html
+++ b/src/app/issues/templates/nav_tabs.html
@@ -15,7 +15,7 @@
 
   <!-- Create RFPs -->
   <li ng-class="active_tab('proposals')" ng-if="showProposalsTab()">
-    <a ng-href="/issues/{{issue.slug}}/proposals">
+    <a ng-href="/issues/{{issue.slug}}/proposals" ng-click-require-auth>
       Proposals
     </a>
   </li>


### PR DESCRIPTION
As a user who is not signed in
When I visit an issue page and click the proposals tab
I am redirected to sign in
Then I sign in
Then I a redirected to the proposals page
