### PR TITLE
README.md: update KiwiIRC button

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # Bountysource
-[![Visit our IRC channel](https://kiwiirc.com/buttons/irc.freenode.net/Bountysource.png)](https://kiwiirc.com/client/irc.freenode.net/?nick=Bountyuser|?#Bountysource)
+[![Visit our IRC channel](https://kiwiirc.com/buttons/chat.freenode.net/Bountysource.png)](https://kiwiirc.com/client/chat.freenode.net:+6697/?nick=Bountyuser|?#Bountysource)
 
 
 [![Bountysource](https://www.bountysource.com/badge/team?team_id=1&style=bounties_posted)](https://www.bountysource.com/teams/bountysource/bounties?utm_source=Bountysource&utm_medium=shield&utm_campaign=bounties_posted)


### PR DESCRIPTION
- Use chat.freenode.net instead of irc.freenode.net
  - It's recommended by freenode everywhere https://freenode.net/irc_servers.shtml
- Use SSL and SSL port to connect to freenode.

I don't know is this the correct branch as the README.md only says that pull requests are welcome and there isn't CONTRIBUTING.md file.
