### PR TITLE
Add BlackCoin as a cash out method

### DIFF
--- a/app/assets/javascripts/admin/api.js
+++ b/app/assets/javascripts/admin/api.js
@@ -804,6 +804,7 @@ angular.module('api.bountysource',[]).
         'Team',
         'CashOut::Paypal',
         'CashOut::Bitcoin',
+        'CashOut::Blackcoin',
         'CashOut::Check'
       ];
     };

--- a/app/assets/javascripts/admin/cash_outs/directives/cashOutTable.html
+++ b/app/assets/javascripts/admin/cash_outs/directives/cashOutTable.html
@@ -78,6 +78,10 @@
         <strong>Bitcoin:</strong><br/> {{cashOut.bitcoin_address}}
       </div>
 
+      <div ng-show="cashOut.blackcoin_address">
+        <strong>BlackCoin:</strong><br/> {{cashOut.blackcoin_address}}
+      </div>
+
       <div ng-show="cashOut.ripple_address">
         <strong>Ripple:</strong><br/> {{cashOut.ripple_address}}
       </div>

--- a/app/assets/javascripts/app/activity/cashOuts/new.html
+++ b/app/assets/javascripts/app/activity/cashOuts/new.html
@@ -164,6 +164,17 @@
               </div>
             </div>
 
+            <!-- Blackcoin -->
+            <div class="form-group" style="margin-bottom: 0;">
+              <div class="col-sm-12">
+                <div class="radio">
+                  <label>
+                    <input type="radio" ng-model="cashOut.type" ng-value="blackcoin'" /> BlackCoin
+                  </label>
+                </div>
+              </div>
+            </div>
+
             <!-- Ripple -->
             <div class="form-group" style="margin-bottom: 0;">
               <div class="col-sm-12">
@@ -206,6 +217,13 @@
         </div>
       </div>
 
+      <!-- Blackcoin Address -->
+      <div class="form-group" ng-if="cashOut.type === 'bitcoin'" ng-class="{ 'has-error': paymentMethodForm.blackcoinAddress.$invalid }">
+        <label class="control-label col-sm-3">BlackCoin Address:</label>
+        <div class="col-sm-9">
+          <input type="text" name="blackcoinAddress" class="form-control" ng-model="cashOut.blackcoin_address" required autocomplete />
+        </div>
+      </div>
 
       <!-- Ripple Address -->
       <div class="form-group" ng-if="cashOut.type === 'ripple'" ng-class="{ 'has-error': paymentMethodForm.rippleAddress.$invalid }">

--- a/app/assets/javascripts/app/activity/cashOuts/new.js
+++ b/app/assets/javascripts/app/activity/cashOuts/new.js
@@ -51,6 +51,7 @@ angular.module('activity').
       amount: undefined,
       paypal_address: undefined,
       bitcoin_address: undefined,
+      blackcoin_address: undefined,
       address: undefined,
       mailing_address: undefined,
       us_citizen: undefined,
@@ -147,9 +148,10 @@ angular.module('activity').
           delete payload.newAddress;
           delete payload.newMailingAddress;
 
-          // Remove paypal/bitcoin if wrong type of cash out
+          // Clear addresses for other types of cash outs
           if (payload.type !== 'paypal') { delete payload.paypal_address; }
           if (payload.type !== 'bitcoin') { delete payload.bitcoin_address; }
+          if (payload.type !== 'blackcoin') { delete payload.blackcoin_address; }
 
           $api.v2.createCashOut(payload).then(function(response) {
             if (response.success) {

--- a/app/assets/javascripts/app/cart/cart.js.erb
+++ b/app/assets/javascripts/app/cart/cart.js.erb
@@ -73,7 +73,7 @@ angular.module('app').controller('ShoppingCartController', function($rootScope, 
   // needs to be a $watch currency can be switched at any time (while on or off this page)
   $scope.$watch(watchCurrency, function (newValue, oldValue) {
     var three_month_value, six_month_value;
-    // can't filter until $currency.btcToUsdRate is set
+    // can't filter until $currency.toUsdRates is set
     // service is a singleton, but if refresh page, needs to load rate first
     $currency.onLoadPromise.then(function () {
       three_month_value = $filter('dollars')(100);

--- a/app/assets/javascripts/app/layout/navbar.html.erb
+++ b/app/assets/javascripts/app/layout/navbar.html.erb
@@ -65,6 +65,7 @@
           <a href="#" class="dropdown-toggle" data-toggle="dropdown">
             <span ng-if="$currency.isUSD()">$</span>
             <span ng-if="$currency.isBTC()">฿</span>
+            <span ng-if="$currency.isBLK()">BLK</span>
             <span ng-if="$currency.isXRP()">XRP</span>
             <span ng-if="$currency.isMSC()">MSC</span>
             <b class="caret"></b>
@@ -73,6 +74,7 @@
             <li role="presentation" class="dropdown-header">Choose currency:</li>
             <li><a ng-click="$currency.setUSD()">US Dollars ($)</a></li>
             <li><a ng-click="$currency.setBTC()">Bitcoin (฿)</a></li>
+            <li><a ng-click="$currency.setBLK()">BlackCoin (BLK)</a></li>
             <li><a ng-click="$currency.setXRP()">Ripple (XRP)</a></li>
             <li><a ng-click="$currency.setMSC()">Mastercoin (MSC)</a></li>
           </ul>

--- a/app/assets/javascripts/common/directives/currencyUnit/currencyUnit.html
+++ b/app/assets/javascripts/common/directives/currencyUnit/currencyUnit.html
@@ -1,6 +1,7 @@
 <span ng-switch on="$currency.value">
   <span ng-switch-when="USD">$</span>
   <span ng-switch-when="BTC">฿</span>
+  <span ng-switch-when="BLK">BLK</span>
   <span ng-switch-when="XRP">XRP</span>
   <span ng-switch-when="MSC">MSC</span>
 </span>

--- a/app/assets/javascripts/common/filters/currencyUnit.js
+++ b/app/assets/javascripts/common/filters/currencyUnit.js
@@ -8,6 +8,8 @@ angular.module('filters').filter('currencyUnit', function ($filter) {
       } else {
         return 'μBTC ';
       }
+    } else if (currency === 'BLK') {
+      return 'BLK';
     } else if (currency === 'XRP') {
       return 'XRP';
     } else if (currency === 'MSC') {

--- a/app/assets/javascripts/common/filters/dollars.js
+++ b/app/assets/javascripts/common/filters/dollars.js
@@ -5,8 +5,8 @@ angular.module('filters').filter('dollars', function($filter, $api, $currency) {
   return function(value, options) {
     options = options || {};
 
-    // Force space between unit and value when MSC and XRP
-    if ($currency.isMSC() || $currency.isXRP()) {
+    // Force space between unit and value when BLK, MSC or XRP
+    if ($currency.isBLK() || $currency.isMSC() || $currency.isXRP()) {
       options.space = true;
     }
 

--- a/app/controllers/api/v2/cash_outs_controller.rb
+++ b/app/controllers/api/v2/cash_outs_controller.rb
@@ -45,6 +45,7 @@ class Api::V2::CashOutsController < Api::BaseController
 
     @item.paypal_address = params[:paypal_address]
     @item.bitcoin_address = params[:bitcoin_address]
+    @item.blackcoin_address = params[:blackcoin_address]
     @item.ripple_address = params[:ripple_address]
     @item.mastercoin_address = params[:mastercoin_address]
 

--- a/app/models/cash_out.rb
+++ b/app/models/cash_out.rb
@@ -24,12 +24,14 @@
 #  mastercoin_address         :string(255)
 #  is_refund                  :boolean          default(FALSE), not null
 #  account_id                 :integer          not null
+#  blackcoin_address          :string(255)
 #
 # Indexes
 #
 #  index_cash_outs_on_address_id          (address_id)
 #  index_cash_outs_on_amount              (amount)
 #  index_cash_outs_on_bitcoin_address     (bitcoin_address)
+#  index_cash_outs_on_blackcoin_address   (blackcoin_address)
 #  index_cash_outs_on_mailing_address_id  (mailing_address_id)
 #  index_cash_outs_on_paypal_address      (paypal_address)
 #  index_cash_outs_on_person_id           (person_id)
@@ -146,11 +148,12 @@ class CashOut < ActiveRecord::Base
   # Given a cash out type, create an instance from the correct class
   def self.parse(type, attrs={})
     klass = case type
-    when 'paypal' then CashOut::Paypal
-    when 'bitcoin' then CashOut::Bitcoin
-    when 'check' then CashOut::Check
-    when 'ripple' then CashOut::Ripple
-    when 'mastercoin' then CashOut::Mastercoin
+    when 'paypal' then Paypal
+    when 'bitcoin' then Bitcoin
+    when 'blackcoin' then Blackcoin
+    when 'check' then Check
+    when 'ripple' then Ripple
+    when 'mastercoin' then Mastercoin
     else raise InvalidType
     end
     klass.new(attrs)

--- a/app/models/cash_out/bitcoin.rb
+++ b/app/models/cash_out/bitcoin.rb
@@ -24,12 +24,14 @@
 #  mastercoin_address         :string(255)
 #  is_refund                  :boolean          default(FALSE), not null
 #  account_id                 :integer          not null
+#  blackcoin_address          :string(255)
 #
 # Indexes
 #
 #  index_cash_outs_on_address_id          (address_id)
 #  index_cash_outs_on_amount              (amount)
 #  index_cash_outs_on_bitcoin_address     (bitcoin_address)
+#  index_cash_outs_on_blackcoin_address   (blackcoin_address)
 #  index_cash_outs_on_mailing_address_id  (mailing_address_id)
 #  index_cash_outs_on_paypal_address      (paypal_address)
 #  index_cash_outs_on_person_id           (person_id)

--- a/app/models/cash_out/blackcoin.rb
+++ b/app/models/cash_out/blackcoin.rb
@@ -40,6 +40,8 @@
 #  index_cash_outs_on_us_citizen          (us_citizen)
 #
 
-class CashOut::Mastercoin < CashOut
-  validates :mastercoin_address, presence: true
+class CashOut::Blackcoin < CashOut
+
+  validates :blackcoin_address, presence: true
+
 end

--- a/app/models/cash_out/check.rb
+++ b/app/models/cash_out/check.rb
@@ -24,12 +24,14 @@
 #  mastercoin_address         :string(255)
 #  is_refund                  :boolean          default(FALSE), not null
 #  account_id                 :integer          not null
+#  blackcoin_address          :string(255)
 #
 # Indexes
 #
 #  index_cash_outs_on_address_id          (address_id)
 #  index_cash_outs_on_amount              (amount)
 #  index_cash_outs_on_bitcoin_address     (bitcoin_address)
+#  index_cash_outs_on_blackcoin_address   (blackcoin_address)
 #  index_cash_outs_on_mailing_address_id  (mailing_address_id)
 #  index_cash_outs_on_paypal_address      (paypal_address)
 #  index_cash_outs_on_person_id           (person_id)

--- a/app/models/cash_out/paypal.rb
+++ b/app/models/cash_out/paypal.rb
@@ -24,12 +24,14 @@
 #  mastercoin_address         :string(255)
 #  is_refund                  :boolean          default(FALSE), not null
 #  account_id                 :integer          not null
+#  blackcoin_address          :string(255)
 #
 # Indexes
 #
 #  index_cash_outs_on_address_id          (address_id)
 #  index_cash_outs_on_amount              (amount)
 #  index_cash_outs_on_bitcoin_address     (bitcoin_address)
+#  index_cash_outs_on_blackcoin_address   (blackcoin_address)
 #  index_cash_outs_on_mailing_address_id  (mailing_address_id)
 #  index_cash_outs_on_paypal_address      (paypal_address)
 #  index_cash_outs_on_person_id           (person_id)

--- a/app/models/cash_out/ripple.rb
+++ b/app/models/cash_out/ripple.rb
@@ -24,12 +24,14 @@
 #  mastercoin_address         :string(255)
 #  is_refund                  :boolean          default(FALSE), not null
 #  account_id                 :integer          not null
+#  blackcoin_address          :string(255)
 #
 # Indexes
 #
 #  index_cash_outs_on_address_id          (address_id)
 #  index_cash_outs_on_amount              (amount)
 #  index_cash_outs_on_bitcoin_address     (bitcoin_address)
+#  index_cash_outs_on_blackcoin_address   (blackcoin_address)
 #  index_cash_outs_on_mailing_address_id  (mailing_address_id)
 #  index_cash_outs_on_paypal_address      (paypal_address)
 #  index_cash_outs_on_person_id           (person_id)

--- a/app/models/currency.rb
+++ b/app/models/currency.rb
@@ -22,10 +22,10 @@ class Currency < ActiveRecord::Base
   validates :value, numericality: { presence: true, greather_than_or_equal_to: 0 }
 
   def self.sync_all
-    [
-      Currency::Bitcoin,
-      Currency::Mastercoin,
-      Currency::Ripple
+    [Bitcoin,
+     Blackcoin,
+     Mastercoin,
+     Ripple
     ].each(&:sync)
   end
 
@@ -37,86 +37,35 @@ class Currency < ActiveRecord::Base
     currencies
   end
 
-  def self.btc_rate
-    Currency::Bitcoin.first.value
+  def self.from_symbol(symbol)
+    case symbol
+    when 'BLK'
+      Blackcoin
+    when 'BTC'
+      Bitcoin
+    when 'MSC'
+      Mastercoin
+    when 'XRP'
+      Ripple
+    end
   end
 
-  def self.msc_rate
-    Currency::Mastercoin.first.value
+  def self.rate_to_usd(symbol)
+    case symbol
+    when 'USD'
+      1
+    else
+      currency = from_symbol(symbol)
+      currency.first.value
+    end
   end
 
-  def self.xrp_rate
-    Currency::Ripple.first.value
-  end
-
-  # TODO For the love of god and all that is holy, give this some class.
   def self.convert(amount, from, to)
     amount ||= 0
     amount = amount.to_f if amount.is_a?(String)
     from ||= 'USD'
-    return amount if from == to
-    case from
-    when 'USD'
-      case to
-      when 'BTC' # USD to BTC
-        amount / btc_rate
-      when 'MSC' # USD to MSC
-        amount / msc_rate
-      when 'XRP' # USD to XRP
-        amount / xrp_rate
-      end
-
-    when 'BTC'
-      case to
-      when 'USD' # BTC to USD
-        amount * btc_rate
-      when 'MSC' # BTC to MSC
-        btc_to_usd(amount) * msc_rate
-      when 'XRP' # BTC to XRP
-        btc_to_usd(amount) * xrp_rate
-      end
-
-    when 'MSC'
-      case to
-      when 'USD' # MSC to USD
-        amount * msc_rate
-      when 'BTC' # MSC to BTC
-        msc_to_usd(amount) * btc_rate
-      when 'XRP' # MSC to XRP
-        msc_to_usd(amount) * xrp_rate
-      end
-
-    when 'XRP'
-      case to
-      when 'USD' # XRP to USD
-        amount * xrp_rate
-      when 'BTC' # XRP to BTC
-        xrp_to_usd(amount) * btc_rate
-      when 'MSC' # XRP to MSC
-        xrp_to_usd(amount) * msc_rate
-      end
-    end
-  end
-
-  def self.btc_to_usd(amount)
-    convert(amount, 'BTC', 'USD')
-  end
-
-  def self.msc_to_usd amount
-    convert(amount, 'MSC', 'USD')
-  end
-
-  def self.xrp_to_usd amount
-    convert(amount, 'XRP', 'USD')
-  end
-
-  def self.usd_to_btc amount
-    convert(amount, 'USD', 'BTC')
-  end
-
-  # Convert currency to USD
-  def self.to_usd currency, amount
-    convert(amount, 'USD', currency)
+    rate = rate_to_usd(from) / rate_to_usd(to)
+    amount * rate
   end
 
 end

--- a/app/models/currency/blackcoin.rb
+++ b/app/models/currency/blackcoin.rb
@@ -1,0 +1,35 @@
+# == Schema Information
+#
+# Table name: currencies
+#
+#  id         :integer          not null, primary key
+#  type       :string(255)      not null
+#  value      :decimal(, )      not null
+#  created_at :datetime
+#  updated_at :datetime
+#
+# Indexes
+#
+#  index_currencies_on_type   (type)
+#  index_currencies_on_value  (value)
+#
+
+class Currency::Blackcoin < Currency
+
+  def self.sync
+    response = HTTParty.get('http://coinmarketcap.com/currencies/blackcoin/')
+
+    if response.success?
+      value = response.match(/class="text-large">\$ ([0-9.]+)<\/span>/)[1].to_f
+
+      model = first || new
+      model.value = value
+      model.save
+    end
+  end
+
+  def self.display_name
+    'blackcoin'
+  end
+
+end

--- a/app/views/api/v2/cash_outs/_base.json.jbuilder
+++ b/app/views/api/v2/cash_outs/_base.json.jbuilder
@@ -5,6 +5,7 @@ fee
 fee_adjustment
 paypal_address
 bitcoin_address
+blackcoin_address
 ripple_address
 mastercoin_address
 sent_at

--- a/db/migrate/20160401070557_add_blackcoin_address_to_cash_out.rb
+++ b/db/migrate/20160401070557_add_blackcoin_address_to_cash_out.rb
@@ -1,0 +1,6 @@
+class AddBlackcoinAddressToCashOut < ActiveRecord::Migration
+  def change
+    add_column :cash_outs, :blackcoin_address, :string
+    add_index :cash_outs, :blackcoin_address
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 1) do
+ActiveRecord::Schema.define(version: 20160401070557) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -180,11 +180,13 @@ ActiveRecord::Schema.define(version: 1) do
     t.string   "mastercoin_address"
     t.boolean  "is_refund",                  default: false, null: false
     t.integer  "account_id",                                 null: false
+    t.string   "blackcoin_address"
   end
 
   add_index "cash_outs", ["address_id"], name: "index_cash_outs_on_address_id", using: :btree
   add_index "cash_outs", ["amount"], name: "index_cash_outs_on_amount", using: :btree
   add_index "cash_outs", ["bitcoin_address"], name: "index_cash_outs_on_bitcoin_address", using: :btree
+  add_index "cash_outs", ["blackcoin_address"], name: "index_cash_outs_on_blackcoin_address", using: :btree
   add_index "cash_outs", ["mailing_address_id"], name: "index_cash_outs_on_mailing_address_id", using: :btree
   add_index "cash_outs", ["paypal_address"], name: "index_cash_outs_on_paypal_address", using: :btree
   add_index "cash_outs", ["person_id"], name: "index_cash_outs_on_person_id", using: :btree

--- a/spec/factories/cash_outs.rb
+++ b/spec/factories/cash_outs.rb
@@ -24,12 +24,14 @@
 #  mastercoin_address         :string(255)
 #  is_refund                  :boolean          default(FALSE), not null
 #  account_id                 :integer          not null
+#  blackcoin_address          :string(255)
 #
 # Indexes
 #
 #  index_cash_outs_on_address_id          (address_id)
 #  index_cash_outs_on_amount              (amount)
 #  index_cash_outs_on_bitcoin_address     (bitcoin_address)
+#  index_cash_outs_on_blackcoin_address   (blackcoin_address)
 #  index_cash_outs_on_mailing_address_id  (mailing_address_id)
 #  index_cash_outs_on_paypal_address      (paypal_address)
 #  index_cash_outs_on_person_id           (person_id)

--- a/spec/models/cash_out/blackcoin_spec.rb
+++ b/spec/models/cash_out/blackcoin_spec.rb
@@ -40,6 +40,8 @@
 #  index_cash_outs_on_us_citizen          (us_citizen)
 #
 
-class CashOut::Mastercoin < CashOut
-  validates :mastercoin_address, presence: true
+require 'spec_helper'
+
+describe CashOut::Blackcoin do
+  it { should validate_presence_of(:blackcoin_address) }
 end

--- a/spec/models/cash_out/mastercoin_spec.rb
+++ b/spec/models/cash_out/mastercoin_spec.rb
@@ -24,12 +24,14 @@
 #  mastercoin_address         :string(255)
 #  is_refund                  :boolean          default(FALSE), not null
 #  account_id                 :integer          not null
+#  blackcoin_address          :string(255)
 #
 # Indexes
 #
 #  index_cash_outs_on_address_id          (address_id)
 #  index_cash_outs_on_amount              (amount)
 #  index_cash_outs_on_bitcoin_address     (bitcoin_address)
+#  index_cash_outs_on_blackcoin_address   (blackcoin_address)
 #  index_cash_outs_on_mailing_address_id  (mailing_address_id)
 #  index_cash_outs_on_paypal_address      (paypal_address)
 #  index_cash_outs_on_person_id           (person_id)

--- a/spec/models/cash_out/ripple_spec.rb
+++ b/spec/models/cash_out/ripple_spec.rb
@@ -24,12 +24,14 @@
 #  mastercoin_address         :string(255)
 #  is_refund                  :boolean          default(FALSE), not null
 #  account_id                 :integer          not null
+#  blackcoin_address          :string(255)
 #
 # Indexes
 #
 #  index_cash_outs_on_address_id          (address_id)
 #  index_cash_outs_on_amount              (amount)
 #  index_cash_outs_on_bitcoin_address     (bitcoin_address)
+#  index_cash_outs_on_blackcoin_address   (blackcoin_address)
 #  index_cash_outs_on_mailing_address_id  (mailing_address_id)
 #  index_cash_outs_on_paypal_address      (paypal_address)
 #  index_cash_outs_on_person_id           (person_id)

--- a/spec/models/cash_out_spec.rb
+++ b/spec/models/cash_out_spec.rb
@@ -24,12 +24,14 @@
 #  mastercoin_address         :string(255)
 #  is_refund                  :boolean          default(FALSE), not null
 #  account_id                 :integer          not null
+#  blackcoin_address          :string(255)
 #
 # Indexes
 #
 #  index_cash_outs_on_address_id          (address_id)
 #  index_cash_outs_on_amount              (amount)
 #  index_cash_outs_on_bitcoin_address     (bitcoin_address)
+#  index_cash_outs_on_blackcoin_address   (blackcoin_address)
 #  index_cash_outs_on_mailing_address_id  (mailing_address_id)
 #  index_cash_outs_on_paypal_address      (paypal_address)
 #  index_cash_outs_on_person_id           (person_id)
@@ -67,6 +69,12 @@ describe CashOut do
     describe 'Bitcoin' do
       let(:type) { 'bitcoin' }
       let(:klass) { CashOut::Bitcoin }
+      it_behaves_like 'a cash out method'
+    end
+
+    describe 'Blackcoin' do
+      let(:type) { 'blackcoin' }
+      let(:klass) { CashOut::Blackcoin }
       it_behaves_like 'a cash out method'
     end
 

--- a/spec/models/shopping_cart_spec.rb
+++ b/spec/models/shopping_cart_spec.rb
@@ -668,9 +668,20 @@ describe ShoppingCart do
     let(:amount) { 100 }
 
     before do
-      Currency.stub(:btc_rate) { 900.0 }
-      Currency.stub(:msc_rate) { 800.0 }
-      Currency.stub(:xrp_rate) { 700.0 }
+      Currency.stub(:rate_to_usd) do |symbol|
+        case symbol
+        when 'BLK'
+          1000.0
+        when 'BTC'
+          900.0
+        when 'MSC'
+          800.0
+        when 'XRP'
+          700.0
+        when 'USD'
+          1
+        end
+      end
     end
 
     it 'should stay in USD' do
@@ -680,25 +691,31 @@ describe ShoppingCart do
 
     it 'should convert BTC to USD' do
       cart.add_item item_attributes.merge(amount: amount, currency: 'BTC')
-      cart.calculate_gross.should eq(amount * Currency.btc_rate)
+      cart.calculate_gross.should eq(amount * Currency.rate_to_usd('BTC'))
+    end
+
+    it 'should convert BLK to USD' do
+      cart.add_item item_attributes.merge(amount: amount, currency: 'BLK')
+      cart.calculate_gross.should eq(amount * Currency.rate_to_usd('BLK'))
     end
 
     it 'should convert MSC to USD' do
       cart.add_item item_attributes.merge(amount: amount, currency: 'MSC')
-      cart.calculate_gross.should eq(amount * Currency.msc_rate)
+      cart.calculate_gross.should eq(amount * Currency.rate_to_usd('MSC'))
     end
 
     it 'should convert XRP to USD' do
       cart.add_item item_attributes.merge(amount: amount, currency: 'XRP')
-      cart.calculate_gross.should eq(amount * Currency.xrp_rate)
+      cart.calculate_gross.should eq(amount * Currency.rate_to_usd('XRP'))
     end
 
     it 'should convert all currencies into USD' do
       cart.add_item item_attributes.merge(amount: amount, currency: 'USD')
       cart.add_item item_attributes.merge(amount: amount, currency: 'BTC')
+      cart.add_item item_attributes.merge(amount: amount, currency: 'BLK')
       cart.add_item item_attributes.merge(amount: amount, currency: 'MSC')
       cart.add_item item_attributes.merge(amount: amount, currency: 'XRP')
-      cart.calculate_gross.should eq(amount + (amount * Currency.btc_rate) + (amount * Currency.msc_rate) + (amount * Currency.xrp_rate))
+      cart.calculate_gross.should eq(amount * (1 + Currency.rate_to_usd('BTC') + Currency.rate_to_usd('BLK') + Currency.rate_to_usd('MSC') + Currency.rate_to_usd('XRP')))
     end
   end
 


### PR DESCRIPTION
This pull request also gets rid of some boilerplate code.

Tested using RSpec only.

[BlackCoin](http://blackcoin.co), a Bitcoin descendant created in 2014, is the first community-friendly (i.e. not premined and being free software) cryptocurrency which uses a pure variant of the [Proof-of-stake](https://en.wikipedia.org/wiki/Proof-of-stake) security protocol.

Withdrawals can be processed either directly in BlackCoin or via Bitcoin, using an on-the-fly converter like [ShapeShift](https://shapeshift.io/).
