### PR TITLE
[FIX] Fixes #1076 and #1012, TeamIssue in Indices

### DIFF
--- a/app/indices/team_issue_index.rb
+++ b/app/indices/team_issue_index.rb
@@ -11,7 +11,7 @@ ThinkingSphinx::Index.define(:issue_rank, :name => "team_issue", :with => :activ
 
   has issue.bounty_total
   has issue.can_add_bounty
-  has issue.tracker.team_id
+  has issue.tracker(:id), :as => :tracker_ids
   has issue.participants_count
   has issue.thumbs_up_count
   has issue.remote_created_at


### PR DESCRIPTION
team_issue has trackers, it doesn't have team_id in trackers.