### PR TITLE
GitHub integration fix

### DIFF
--- a/app/assets/javascripts/app/tools/base.js
+++ b/app/assets/javascripts/app/tools/base.js
@@ -99,6 +99,7 @@ angular.module('app').controller('BaseToolsController', function ($scope, $route
   $scope.plugins_promise = $api.tracker_plugins_get().then(function(plugins) {
     // Get the plugin for a tracker, if installed.
     // if not installed, return model for a new plugin
+    console.log(plugins);
     $scope.tracker_plugins_count = plugins.length;
     $scope.get_plugin = function(tracker) {
       if (tracker) {
@@ -139,6 +140,16 @@ angular.module('app').controller('BaseToolsController', function ($scope, $route
         return tracker.$plugin_installed;
       }
     };
+
+    $scope.plugin_locked = function(tracker){
+      if(tracker.$plugin_installed){
+        var plugin = $scope.get_plugin(tracker)
+        if(plugin.locked_at && plugin.locked_at !== ""){
+          return true;
+        }
+      }
+      return false;
+    }
 
     $scope.plugin_alert = { text: '', type: 'warning' };
 

--- a/app/assets/javascripts/app/tools/base.js
+++ b/app/assets/javascripts/app/tools/base.js
@@ -148,7 +148,6 @@ angular.module('app').controller('BaseToolsController', function ($scope, $route
       return true;
     }
     $scope.plugin_locked = function(plugin){
-      console.log(plugin);
       if(plugin.locked_at && plugin.locked_at !== "" &&
         (typeof plugin.locked === 'undefined' || plugin.locked)/**/){
           return true;

--- a/app/assets/javascripts/app/tools/base.js
+++ b/app/assets/javascripts/app/tools/base.js
@@ -141,27 +141,29 @@ angular.module('app').controller('BaseToolsController', function ($scope, $route
         return tracker.$plugin_installed;
       }
     };
+    
     $scope.plugin_save_will_unlock = function(plugin){
       if (typeof plugin.locked === 'undefined' || plugin.locked){
         return false;
       }
       return true;
-    }
+    };
+
     $scope.plugin_locked = function(plugin){
       if(plugin.locked_at && plugin.locked_at !== "" &&
         (typeof plugin.locked === 'undefined' || plugin.locked)/**/){
           return true;
       }
       return false;
-    }
+    };
 
     $scope.tracker_locked = function(tracker){
       if(tracker.$plugin_installed){
-        var plugin = $scope.get_plugin(tracker)
+        var plugin = $scope.get_plugin(tracker);
         return $scope.plugin_locked(plugin);
       }
       return false;
-    }
+    };
     
     $scope.plugin_alert = { text: '', type: 'warning' };
 

--- a/app/assets/javascripts/app/tools/templates/plugin_settings.html
+++ b/app/assets/javascripts/app/tools/templates/plugin_settings.html
@@ -55,7 +55,7 @@
             <br>
           </label>
         </div>
-      </row>
+      </div>
       <div>
         <!-- Modify existing plugin, show save button. Otherwise, show install button -->
         <button ng-show="current_tracker.$plugin_installed" class="btn btn-primary" ng-disabled="!plugin_changed(current_plugin)" ng-click="update_plugin(current_plugin)">Save</button>

--- a/app/assets/javascripts/app/tools/templates/plugin_settings.html
+++ b/app/assets/javascripts/app/tools/templates/plugin_settings.html
@@ -46,6 +46,16 @@
         </div>
       </div>
       <br>
+      <div class="row" ng-show="plugin_locked(current_plugin) || (!saved_unlocked && plugin_save_will_unlock(current_plugin))">
+        <div class="col-sm-12"><label class="">
+            <input type="checkbox" ng-checked="plugin_locked(current_plugin)" ng-model="current_plugin.locked">
+            This plugin is locked.
+            <br>
+            Reason: {{current_plugin.last_error}}
+            <br>
+          </label>
+        </div>
+      </row>
       <div>
         <!-- Modify existing plugin, show save button. Otherwise, show install button -->
         <button ng-show="current_tracker.$plugin_installed" class="btn btn-primary" ng-disabled="!plugin_changed(current_plugin)" ng-click="update_plugin(current_plugin)">Save</button>

--- a/app/assets/javascripts/app/tools/templates/trackers.html
+++ b/app/assets/javascripts/app/tools/templates/trackers.html
@@ -12,7 +12,7 @@
           </span>
         </td>
         <td style="width: 5%;">
-            <span class="label label-warning" ng-show="plugin_locked(tracker)">
+            <span class="label label-warning" ng-show="tracker_locked(tracker)">
               Locked
             </span>
         </td>

--- a/app/assets/javascripts/app/tools/templates/trackers.html
+++ b/app/assets/javascripts/app/tools/templates/trackers.html
@@ -11,7 +11,13 @@
             Installed
           </span>
         </td>
+        <td style="width: 5%;">
+            <span class="label label-warning" ng-show="plugin_locked(tracker)">
+              Locked
+            </span>
+        </td>
         <td><a ng-click="expand_tracker(tracker)">{{tracker.full_name}}</a></td>
+        
       </tr>
       </tbody>
     </table>

--- a/app/controllers/api/v1/tracker_plugins_controller.rb
+++ b/app/controllers/api/v1/tracker_plugins_controller.rb
@@ -25,6 +25,8 @@ class Api::V1::TrackerPluginsController < ApplicationController
     @tracker_plugin.add_label = params[:add_label].to_bool if params.has_key?(:add_label)
     @tracker_plugin.label_name = params[:label_name] if params.has_key?(:label_name)
     @tracker_plugin.label_color = params[:label_color] if params.has_key?(:label_color)
+    @tracker_plugin.last_error = nil
+    @tracker_plugin.locked_at = nil
 
     @tracker_plugin.save!
     render "api/v1/tracker_plugins/show", status: :created
@@ -38,6 +40,11 @@ class Api::V1::TrackerPluginsController < ApplicationController
     @tracker_plugin.modify_body = params[:modify_body].to_bool if params.has_key?(:modify_body)
     @tracker_plugin.label_name = params[:label_name] if params.has_key?(:label_name)
     @tracker_plugin.label_color = params[:label_color] if params.has_key?(:label_color)
+    
+    if params.has_key?(:locked) && !params[:locked].to_bool
+      @tracker_plugin.last_error = nil
+      @tracker_plugin.locked_at = nil
+    end
 
     @tracker_plugin.save!
 

--- a/app/views/api/v1/tracker_plugins/partials/base.rabl
+++ b/app/views/api/v1/tracker_plugins/partials/base.rabl
@@ -7,3 +7,5 @@ attribute :label_name
 attribute :label_color
 attribute :created_at
 attribute :updated_at
+attribute :locked_at
+attribute :last_error


### PR DESCRIPTION
Fix for #1096. Allows the user to see and unlock any locks on their plugins through the tools page. The interface might need some work, but I think it functions properly.

Related things I want to do:
1. Add an uninstall button.
2. Notify/Email a user when their plugin locks.
3. Maybe rework the plugin into a GitHub app?