### PR TITLE
Fix dot-point indentation in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,15 +19,15 @@ Bountysource is run by volunteers, so development activity can be sporadic (to p
 * Start by reading our Wiki's [How to Contribute](https://github.com/bountysource/core/wiki/How-to-Contribute)
 
 * There are a number of high priority issues that would help the core team, such as:
- * [Automatically collect e-signed Tax forms upon cash out request](https://github.com/bountysource/core/issues/1078)
- * [Add "Send via Paypal" button to admin/cash_outs/pending](https://github.com/bountysource/core/issues/1079)
- * [Add "Send via Coinbase" button to admin/cash_outs/pending](https://github.com/bountysource/core/issues/1080)
- * ["Add an issue tracker that your team manages" does not do anything](https://github.com/bountysource/core/issues/1023)
+  * [Automatically collect e-signed Tax forms upon cash out request](https://github.com/bountysource/core/issues/1078)
+  * [Add "Send via Paypal" button to admin/cash_outs/pending](https://github.com/bountysource/core/issues/1079)
+  * [Add "Send via Coinbase" button to admin/cash_outs/pending](https://github.com/bountysource/core/issues/1080)
+  * ["Add an issue tracker that your team manages" does not do anything](https://github.com/bountysource/core/issues/1023)
 
 * Looking for some easier tasks to get started?
- * [Improve forgot/reset password usability](https://github.com/bountysource/core/issues/1030)
- * [Fee in fees page and TOS do not match.](https://github.com/bountysource/core/issues/994)
- * [Change "Support team" text if you're a supporter](https://github.com/bountysource/core/issues/1002)
+  * [Improve forgot/reset password usability](https://github.com/bountysource/core/issues/1030)
+  * [Fee in fees page and TOS do not match.](https://github.com/bountysource/core/issues/994)
+  * [Change "Support team" text if you're a supporter](https://github.com/bountysource/core/issues/1002)
 
 ## Developer Resources
 


### PR DESCRIPTION
The sub-points were indented with a single space,
which Markdown doesn't recognise.
They're now indented with two spaces.