### PR TITLE
GitHub integration: fix message to avoid ambiguity

### DIFF
--- a/app/models/tracker_plugin/gh.rb
+++ b/app/models/tracker_plugin/gh.rb
@@ -244,7 +244,7 @@ protected
     elsif is_open && unclaimed_bounties == 0
       plugin_text = %(Want to back this issue? **[Post a bounty on it!](#{issue_url})** We accept bounties via [Bountysource](#{bountysource_url}).)
     elsif !is_open && unclaimed_bounties > 0
-      plugin_text = %(Did you help close this issue? Go claim the **[#{number_to_dollars(unclaimed_bounties)} bounty](#{issue_url})** on [Bountysource](#{bountysource_url}).)
+      plugin_text = %(Did you fix this issue? Go claim the **[#{number_to_dollars(unclaimed_bounties)} bounty](#{issue_url})** on [Bountysource](#{bountysource_url}).)
     elsif !is_open && claimed_bounties > 0
       plugin_text = %(The **[#{number_to_dollars(claimed_bounties)} bounty](#{issue_url})** on this issue has been claimed at [Bountysource](#{bountysource_url}).)
     else


### PR DESCRIPTION
The message prompting developers to claim a bounty was ambiguous, as it could be interpreted as suggesting that multiple people who collaborated on an issue could all claim the bounty.

In fact, each bounty can only be claimed by a single developer, so submitting multiple claims would initiate a contesting process where the funder(s) decide who gets 100% of the bounty.

This change avoids the ambiguity by using more direct language.

For context, such a misunderstanding happened at https://github.com/elementary/icons/issues/84#issuecomment-429536967.
There's already an issue for supporting multiple claims on a bounty from develpers who collaborated, rather than competed, on a solution: #546.