### PR TITLE
Fix welcome-email Bounty source search link

### DIFF
--- a/app/views/mailer/account_created.html.erb
+++ b/app/views/mailer/account_created.html.erb
@@ -13,7 +13,7 @@
 <p>When you <a href="<%= "#{Api::Application.config.www_url}teams/new?utm_source=welcome&utm_medium=email&utm_campaign=createteam" %>">create a Team</a>, you can streamline all fundraising efforts by having them in one place -- bounties, fundraisers, and project donations are all centered around Teams.</p>
 
 <h3>Earn money while improving open-source</h3>
-<p>Use our <a href="<%= "#{Api::Application.config.www_url}bounties/search?utm_source=welcome&utm_medium=email&utm_campaign=bountysearch" %>">Bounty Search</a> to discover active bounties. You can filter by project, language, bounty amount, and more.</p>
+<p>Use our <a href="<%= "#{Api::Application.config.www_url}?utm_source=welcome&utm_medium=email&utm_campaign=bountysearch" %>">Bounty Search</a> to discover active bounties. You can filter by project, language, bounty amount, and more.</p>
 
 <h3>Have an issue you want to see solved?</h3>
 <p>Paste the issue URL (e.g. "https://github.com/owner/project/issues/123") into our search and post a bounty on it.</p>

--- a/app/views/mailer/account_created.text.erb
+++ b/app/views/mailer/account_created.text.erb
@@ -15,7 +15,7 @@ Install the GitHub plugin: If you're looking for a way to start promoting bounti
 
 Grow your project: When you create a Team (<%= Api::Application.config.www_url %>teams/new), you can streamline all fundraising efforts by having them in one place -- bounties, fundraisers, project donations are all centered around Teams.
 
-Earn money while improving open-source: Use our Bounty Search (<%= Api::Application.config.www_url %>bounties/search) to discover active bounties. You can filter by project, language, bounty amount, and more.
+Earn money while improving open-source: Use our Bounty Search (<%= Api::Application.config.www_url %>) to discover active bounties. You can filter by project, language, bounty amount, and more.
 
 Have an issue you want to see solved? Paste the issue URL (e.g. "https://github.com/owner/project/issues/123") into our search and post a bounty on it.
 


### PR DESCRIPTION
fixes #1372 

The welcome-email link to search page need to be updated to home page since previous URL doesn't exist anymore.