### PR TITLE
temporarily disable prepared statements:

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -121,3 +121,5 @@ group :production do
   gem 'ngannotate-rails'
   gem 'rack-timeout'
 end
+
+gem "barnes"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -67,6 +67,9 @@ GEM
     aws-sigv4 (1.0.2)
     aws_cf_signer (0.1.3)
     backports (3.11.1)
+    barnes (0.0.8)
+      multi_json (~> 1)
+      statsd-ruby (~> 1.1)
     bcrypt (3.1.10)
     better_errors (2.4.0)
       coderay (>= 1.0.0)
@@ -541,6 +544,7 @@ GEM
       actionpack (>= 4.0)
       activesupport (>= 4.0)
       sprockets (>= 3.0.0)
+    statsd-ruby (1.4.0)
     stripe (3.11.0)
       faraday (~> 0.10)
     temple (0.8.0)
@@ -593,6 +597,7 @@ DEPENDENCIES
   annotate
   api-versions
   asset_sync
+  barnes
   bcrypt (= 3.1.10)
   better_errors
   binding_of_caller

--- a/app/models/github/issue.rb
+++ b/app/models/github/issue.rb
@@ -76,7 +76,7 @@ class Github::Issue < ::Issue
     if synced_at.nil? || deleted_at
       remote_sync(options)
     elsif synced_at < 1.minute.ago
-      delay.remote_sync(options)
+      delay(priority: 150).remote_sync(options)
     else
       # no syncing since we've sync'd within past minute
     end
@@ -107,7 +107,7 @@ class Github::Issue < ::Issue
       rate_limit_resets_at = error.response.headers['x-ratelimit-reset'][0]
       reset_time = Time.strptime(rate_limit_resets_at, "%s")
 
-      delay(run_at: reset_time, priority: 100).remote_sync(options)
+      delay(run_at: reset_time, priority: 150).remote_sync(options)
     end
   end
 

--- a/app/models/github/issue.rb
+++ b/app/models/github/issue.rb
@@ -107,7 +107,7 @@ class Github::Issue < ::Issue
       rate_limit_resets_at = error.response.headers['x-ratelimit-reset'][0]
       reset_time = Time.strptime(rate_limit_resets_at, "%s")
 
-      delay(run_at: reset_time).remote_sync(options)
+      delay(run_at: reset_time, priority: 150).remote_sync(options)
     end
   end
 

--- a/app/models/github/issue.rb
+++ b/app/models/github/issue.rb
@@ -107,7 +107,7 @@ class Github::Issue < ::Issue
       rate_limit_resets_at = error.response.headers['x-ratelimit-reset'][0]
       reset_time = Time.strptime(rate_limit_resets_at, "%s")
 
-      delay(run_at: reset_time, priority: 150).remote_sync(options)
+      delay(run_at: reset_time, priority: 100).remote_sync(options)
     end
   end
 

--- a/app/models/person.rb
+++ b/app/models/person.rb
@@ -299,7 +299,7 @@ class Person < ApplicationRecord
   end
 
   def send_email(which, options={})
-    Rails.env.test? ? deliver_email(which, options) : delay.deliver_email(which, options)
+    Rails.env.test? ? deliver_email(which, options) : delay(priority: 25).deliver_email(which, options)
   end
 
   def deliver_email(which, options={})

--- a/config/database.yml
+++ b/config/database.yml
@@ -48,6 +48,7 @@ params = CGI.parse(uri.query || "")
   <%= attribute "host",     host %>
   <%= attribute "port",     port %>
   pool: 10
+  prepared_statement: false
 
 <% params.each do |key, value| %>
   <%= key %>: <%= value.first %>

--- a/config/database.yml
+++ b/config/database.yml
@@ -40,6 +40,10 @@ params = CGI.parse(uri.query || "")
 
 %>
 
+default: &default
+  pool: 10
+  prepared_statements: false
+
 <%= ENV["RAILS_ENV"] || ENV["RACK_ENV"] %>:
   <%= attribute "adapter",  adapter %>
   <%= attribute "database", database %>
@@ -47,8 +51,6 @@ params = CGI.parse(uri.query || "")
   <%= attribute "password", password, true %>
   <%= attribute "host",     host %>
   <%= attribute "port",     port %>
-  pool: 10
-  prepared_statement: false
 
 <% params.each do |key, value| %>
   <%= key %>: <%= value.first %>


### PR DESCRIPTION
Prepared statements are currently causing errors due to failed cleanups (and potentially known issues in the older version of rails we are using). This is to temporarily disable them to avoid errors while we fix other more pressing issues