### PR TITLE
improve bounties query

### DIFF
--- a/app/models/bounty.rb
+++ b/app/models/bounty.rb
@@ -65,7 +65,7 @@ class Bounty < ApplicationRecord
   scope :active, lambda { where(status: Status::ACTIVE) }
   scope :refunded, lambda { where(status: Status::REFUNDED) }
   scope :paid, lambda { where(status: Status::PAID) }
-  scope :not_refunded, lambda { where("status != :status", status: Status::REFUNDED) }
+  scope :not_refunded, lambda { where("status < :status AND status > :status", status: Status::REFUNDED) }
 
   # A bounty is visible so long as it has not been refunded, and is not anon
   scope :visible, lambda { where("anonymous = false AND status != :status", status: Status::REFUNDED) }


### PR DESCRIPTION
This query is run during `remote_sync`, but does not use the `index` on `status` due to the `!=`. Using a combination of > and < does however use the index, and running an `EXPLAIN` on the query indicates that it will run much faster after this change.