### PR TITLE
fix: missing backer information and cross origin errors

### DIFF
--- a/app/controllers/track_controller.rb
+++ b/app/controllers/track_controller.rb
@@ -18,4 +18,22 @@ class TrackController < ActionController::Base
     head :ok
   end
 
+  def decide
+    # from first reply in https://community.mixpanel.com/sending-data-to-mixpanel-11/decide-endpoint-is-throwing-error-500s-on-page-load-1669
+    # decide endpoint of a URL is responsible for providing checks to deliver in-apps and a/b test options to users
+    # not using but called by javascript lib anyway, so set up empty response here with appropriate headers
+    
+    # mixpanel sends withCrednetials so mp_optout is respected but that's not allowed with a *
+    headers['Access-Control-Allow-Origin'] = request.headers['Origin'] || '*'
+    headers['Access-Control-Allow-Credentials'] = true
+
+    headers['Access-Control-Allow-Methods'] = 'GET, POST, PATCH, PUT, DELETE'
+    headers['Access-Control-Allow-Headers'] = 'Authorization, Content-Type, If-Match, If-Modified-Since, If-None-Match, If-Unmodified-Since, X-Requested-With'
+    headers['Access-Control-Max-Age'] = '86400'
+    headers['Cache-Control'] = "no-cache, no-store, max-age=0, must-revalidate"
+    headers['Pragma'] = "no-cache"
+    headers['Expires'] = "Fri, 01 Jan 1990 00:00:00 GMT"
+    head :ok
+  end
+
 end

--- a/app/controllers/track_controller.rb
+++ b/app/controllers/track_controller.rb
@@ -18,22 +18,4 @@ class TrackController < ActionController::Base
     head :ok
   end
 
-  def decide
-    # from first reply in https://community.mixpanel.com/sending-data-to-mixpanel-11/decide-endpoint-is-throwing-error-500s-on-page-load-1669
-    # decide endpoint of a URL is responsible for providing checks to deliver in-apps and a/b test options to users
-    # not using but called by javascript lib anyway, so set up empty response here with appropriate headers
-    
-    # mixpanel sends withCrednetials so mp_optout is respected but that's not allowed with a *
-    headers['Access-Control-Allow-Origin'] = request.headers['Origin'] || '*'
-    headers['Access-Control-Allow-Credentials'] = true
-
-    headers['Access-Control-Allow-Methods'] = 'GET, POST, PATCH, PUT, DELETE'
-    headers['Access-Control-Allow-Headers'] = 'Authorization, Content-Type, If-Match, If-Modified-Since, If-None-Match, If-Unmodified-Since, X-Requested-With'
-    headers['Access-Control-Max-Age'] = '86400'
-    headers['Cache-Control'] = "no-cache, no-store, max-age=0, must-revalidate"
-    headers['Pragma'] = "no-cache"
-    headers['Expires'] = "Fri, 01 Jan 1990 00:00:00 GMT"
-    head :ok
-  end
-
 end

--- a/app/models/bounty.rb
+++ b/app/models/bounty.rb
@@ -65,7 +65,7 @@ class Bounty < ApplicationRecord
   scope :active, lambda { where(status: Status::ACTIVE) }
   scope :refunded, lambda { where(status: Status::REFUNDED) }
   scope :paid, lambda { where(status: Status::PAID) }
-  scope :not_refunded, lambda { where("status != :status", status: Status::REFUNDED) }
+  scope :not_refunded, lambda { where("status < :status OR status > :status", status: Status::REFUNDED) }
   # A bounty is visible so long as it has not been refunded, and is not anon
   scope :visible, lambda { where("anonymous = false AND status != :status", status: Status::REFUNDED) }
 

--- a/app/models/bounty.rb
+++ b/app/models/bounty.rb
@@ -65,12 +65,11 @@ class Bounty < ApplicationRecord
   scope :active, lambda { where(status: Status::ACTIVE) }
   scope :refunded, lambda { where(status: Status::REFUNDED) }
   scope :paid, lambda { where(status: Status::PAID) }
-  scope :not_refunded, lambda { where("status < :status AND status > :status", status: Status::REFUNDED) }
-
+  scope :not_refunded, lambda { where("status != :status", status: Status::REFUNDED) }
   # A bounty is visible so long as it has not been refunded, and is not anon
   scope :visible, lambda { where("anonymous = false AND status != :status", status: Status::REFUNDED) }
 
-  scope :expiring_soon,       lambda { |date=2.weeks.from_now, count=nil| where('expires_at < ?', date).order('expires_at desc').limit(count) }
+  scope :expiring_soon, lambda { |date=2.weeks.from_now, count=nil| where('expires_at < ?', date).order('expires_at desc').limit(count) }
 
   # bounties that count toward the displayed bounty total of issues
   scope :valuable, lambda { active.where('amount > 0') }

--- a/app/models/mixpanel_event.rb
+++ b/app/models/mixpanel_event.rb
@@ -39,7 +39,7 @@ class MixpanelEvent < ApplicationRecord
       MixpanelAlias.claim(person_id, distinct_id)
     elsif !distinct_id.nil? && person_id.nil?
       distinct_id = distinct_id.to_s
-      person_id = MixpanelAlias.find_by(distinct_id: distinct_id).pluck(:person_id) # not guaranteed
+      person_id = MixpanelAlias.find_by(distinct_id: distinct_id).person_id # not guaranteed
     else
       raise "Missing distinct_id and person_id"
     end

--- a/app/views/layouts/_env.html.erb
+++ b/app/views/layouts/_env.html.erb
@@ -6,7 +6,7 @@
     salt_host: '<%=Api::Application.config.salt_url%>',
     www_host: '<%=Api::Application.config.www_url%>',
     mixpanel: '<%=Api::Application.config.mixpanel_token%>',
-    mixpanel_config: { 'api_host': '<%=Api::Application.config.api_url%>'.replace(/\/$/,'') },
+    mixpanel_config: { 'api_host': '<%=Api::Application.config.api_url%>'.replace(/\/$/,''), 'autotrack': false },
     google_analytics: '<%=ENV['GOOGLE_ANALYTICS_SITE']%>',
     stripe_key: '<%=ENV['STRIPE_PUBLIC_KEY']%>',
     stripe_image: 'https://s3.amazonaws.com/stripe-uploads/acct_15jcQ4LM04M7PZLcmerchant-icon-1427143578024-Bountysource-square-100.png',

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -51,7 +51,6 @@ Api::Application.routes.draw do
 
     # track user generated events (compatible with mixpanel API)
     match '/track', to: 'track#track', via: :post
-    match '/decide', to: 'track#decide', via: :get
 
     # All things money related
     scope path: 'payments', controller: 'payments' do

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -50,7 +50,8 @@ Api::Application.routes.draw do
     get '/badge/team', to: 'badge#team'
 
     # track user generated events (compatible with mixpanel API)
-    match '/track', to: 'track#track', via: :get
+    match '/track', to: 'track#track', via: :post
+    match '/decide', to: 'track#decide', via: :get
 
     # All things money related
     scope path: 'payments', controller: 'payments' do


### PR DESCRIPTION
Resolves #1465 

### Description
Fixed a couple of errors:
- Empty backers list in issue/bounty page due to `bounty_refunded` failing query
- Cross-origin errors caused by failing API calls due to some routing errors and a querying error.

**Changes made**
- Change made in #1454 broke the bounty not_refunded query. Affecting the backer's list in the issue/bounty page, switched to `OR`.
- Removed `.pluck` method call as the switch to `find_by` in #1442 returns the model instance (instead of a collection like previously) which does not have the method. Refer to `person_id` field directly.
- Disabled 'autotrack' to stop Mixpanel client lib from calling `decide` API route.
- Changed 'track' API route for Mixpanel to accept appropriate POST method instead of GET which doesn't accept the send form data.
