### PR TITLE
fix: currency filter issue causing $NaN in receipt

### DIFF
--- a/app/assets/javascripts/app/orders/show.html.erb
+++ b/app/assets/javascripts/app/orders/show.html.erb
@@ -244,7 +244,7 @@
         <div class="col-xs-3">
           <div class="panel panel-cool-grey">
             <div class="panel-heading text-center">
-              Total ({{ transaction.items.length | number }}<ng-pluralize count="transaction.items.length" when="{ '1': 'item', 'other': 'items' }"></ng-pluralize>): {{ transaction.gross || 0 | dollars:{ precision: {'USD': 2} } }}
+              Total ({{ transaction.items.length | number }}<ng-pluralize count="transaction.items.length" when="{ '1': 'item', 'other': 'items' }"></ng-pluralize>): {{ transaction.gross || 0 | dollars }}
             </div>
             <div class="panel-body">
               <div>


### PR DESCRIPTION
Resolves #1464 

Simple fix, there isn't a `precision` option in the AngularJS [currency filter API](https://code.angularjs.org/1.2.16/docs/api/ng/filter/currency) with the version we're using. 