### PR TITLE
Alpha/fix team claims and speed up other pages

### DIFF
--- a/app/assets/javascripts/admin/api.js
+++ b/app/assets/javascripts/admin/api.js
@@ -33,7 +33,7 @@ angular.module('api.bountysource',[]).
       if ($cookieJar.getJson($api.access_token_cookie_name)) {
         params.access_token = $cookieJar.getJson($api.access_token_cookie_name);
       }
-      params.per_page = params.per_page || 250;
+      params.per_page = params.per_page || 10;
 
       // deferred JSONP call with a promise
       var deferred = $q.defer();
@@ -102,7 +102,7 @@ angular.module('api.bountysource',[]).
       if ($cookieJar.getJson($api.access_token_cookie_name)) {
         params.access_token = $cookieJar.getJson($api.access_token_cookie_name);
       }
-      params.per_page = params.per_page || 250;
+      params.per_page = params.per_page || 10;
 
       // deferred JSONP call with a promise
       var deferred = $q.defer();

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,6 +6,8 @@ services:
   pgsql:
     container_name: pgsql
     image: postgres
+    environment: 
+      POSTGRES_PASSWORD: password
     volumes:
       - database:/var/lib/postgresql/data
     ports:


### PR DESCRIPTION
Every api call unnecessarily fetches 250 items, which slows down the app when there are too many rows. I've added an index to the DB, but this should help speed up many of the pages where lists of items are shown.